### PR TITLE
[Task1] Add KIS settings schema + validation tests

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -1,0 +1,28 @@
+import os
+from functools import lru_cache
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class Settings(BaseModel):
+    KIS_APP_KEY: str
+    KIS_APP_SECRET: str
+    KIS_ACCOUNT_NO: str
+    KIS_ENV: Literal["mock", "live"]
+
+    @classmethod
+    def from_env(cls) -> "Settings":
+        return cls.model_validate(
+            {
+                "KIS_APP_KEY": os.getenv("KIS_APP_KEY"),
+                "KIS_APP_SECRET": os.getenv("KIS_APP_SECRET"),
+                "KIS_ACCOUNT_NO": os.getenv("KIS_ACCOUNT_NO"),
+                "KIS_ENV": os.getenv("KIS_ENV"),
+            }
+        )
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings.from_env()

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,10 @@
 from fastapi import FastAPI
 
 from app.api.routes import router
+from app.config.settings import get_settings
 
 app = FastAPI(title="KIS Trading Gateway", version="0.1.0")
 app.include_router(router, prefix="/v1")
+
+# NOTE: lazy-loaded so app import does not require env during tests.
+app.state.get_settings = get_settings

--- a/tests/test_kis_config.py
+++ b/tests/test_kis_config.py
@@ -1,0 +1,33 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from pydantic import ValidationError
+
+from app.config.settings import Settings
+
+
+class TestKisSettings(unittest.TestCase):
+    def test_missing_required_env_fails_validation(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(ValidationError):
+                Settings.from_env()
+
+    def test_valid_env_loads_settings(self):
+        env = {
+            "KIS_APP_KEY": "app-key",
+            "KIS_APP_SECRET": "app-secret",
+            "KIS_ACCOUNT_NO": "12345678-01",
+            "KIS_ENV": "mock",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            settings = Settings.from_env()
+
+        self.assertEqual(settings.KIS_APP_KEY, "app-key")
+        self.assertEqual(settings.KIS_APP_SECRET, "app-secret")
+        self.assertEqual(settings.KIS_ACCOUNT_NO, "12345678-01")
+        self.assertEqual(settings.KIS_ENV, "mock")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add KIS settings schema (`app/config/settings.py`)
- include required envs: `KIS_APP_KEY`, `KIS_APP_SECRET`, `KIS_ACCOUNT_NO`, `KIS_ENV(mock|live)`
- add config tests (`tests/test_kis_config.py`)
- wire minimal lazy settings loader in `app/main.py`

## Verification
- python3 -m unittest tests/test_kis_config.py -v
- python3 -m unittest discover -s tests -v
- result: 24 passed
