### PR TITLE
[Task2] Add KIS REST quote client

### DIFF
--- a/app/integrations/kis_rest.py
+++ b/app/integrations/kis_rest.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Optional
+
+import requests
+
+
+class KisRestClient:
+    """Minimal KIS REST quote client with token issuance and quote retrieval."""
+
+    _BASE_URLS = {
+        "mock": "https://openapivts.koreainvestment.com:29443",
+        "live": "https://openapi.koreainvestment.com:9443",
+    }
+
+    def __init__(
+        self,
+        app_key: str,
+        app_secret: str,
+        env: str = "mock",
+        session: Optional[Any] = None,
+        base_url: Optional[str] = None,
+    ) -> None:
+        if env not in self._BASE_URLS and base_url is None:
+            raise ValueError("env must be one of: mock, live")
+
+        self.app_key = app_key
+        self.app_secret = app_secret
+        self.env = env
+        self.base_url = base_url or self._BASE_URLS[env]
+        self.session = session or requests
+        self._access_token: Optional[str] = None
+        self._token_expires_at: float = 0.0
+
+    def _issue_token(self) -> str:
+        response = self.session.post(
+            f"{self.base_url}/oauth2/tokenP",
+            headers={"content-type": "application/json"},
+            json={
+                "grant_type": "client_credentials",
+                "appkey": self.app_key,
+                "appsecret": self.app_secret,
+            },
+            timeout=5,
+        )
+        response.raise_for_status()
+        payload = response.json()
+
+        token = payload["access_token"]
+        expires_in = int(payload.get("expires_in", 3600))
+        self._access_token = token
+        # refresh a bit earlier
+        self._token_expires_at = time.time() + max(expires_in - 30, 0)
+        return token
+
+    def get_access_token(self) -> str:
+        if self._access_token and time.time() < self._token_expires_at:
+            return self._access_token
+        return self._issue_token()
+
+    @staticmethod
+    def _to_float(value: Any, default: float = 0.0) -> float:
+        try:
+            if value is None or value == "":
+                return default
+            return float(value)
+        except (TypeError, ValueError):
+            return default
+
+    def get_quote(self, symbol: str) -> Dict[str, Any]:
+        token = self.get_access_token()
+
+        response = self.session.get(
+            f"{self.base_url}/uapi/domestic-stock/v1/quotations/inquire-price",
+            headers={
+                "authorization": f"Bearer {token}",
+                "appkey": self.app_key,
+                "appsecret": self.app_secret,
+                "tr_id": "FHKST01010100",
+            },
+            params={"fid_cond_mrkt_div_code": "J", "fid_input_iscd": symbol},
+            timeout=5,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        output = payload.get("output", {})
+
+        return {
+            "symbol": symbol,
+            "price": self._to_float(output.get("stck_prpr")),
+            "change_pct": self._to_float(output.get("prdy_ctrt")),
+            "turnover": self._to_float(output.get("acml_tr_pbmn")),
+            "source": "kis-rest",
+            "ts": int(time.time()),
+        }

--- a/tests/test_kis_rest_client.py
+++ b/tests/test_kis_rest_client.py
@@ -1,0 +1,99 @@
+import unittest
+from unittest.mock import MagicMock
+
+from app.integrations.kis_rest import KisRestClient
+
+
+class TestKisRestClient(unittest.TestCase):
+    def test_get_quote_parses_response_and_auth_flow(self):
+        session = MagicMock()
+
+        token_response = MagicMock()
+        token_response.json.return_value = {
+            "access_token": "token-123",
+            "expires_in": 3600,
+        }
+        token_response.raise_for_status.return_value = None
+
+        quote_response = MagicMock()
+        quote_response.json.return_value = {
+            "output": {
+                "stck_prpr": "71200",
+                "prdy_ctrt": "1.35",
+                "acml_tr_pbmn": "123456789",
+            }
+        }
+        quote_response.raise_for_status.return_value = None
+
+        session.post.return_value = token_response
+        session.get.return_value = quote_response
+
+        client = KisRestClient(
+            app_key="app-key",
+            app_secret="app-secret",
+            env="mock",
+            session=session,
+            base_url="https://example.test",
+        )
+
+        quote = client.get_quote("005930")
+
+        self.assertEqual(quote["symbol"], "005930")
+        self.assertEqual(quote["price"], 71200.0)
+        self.assertEqual(quote["change_pct"], 1.35)
+        self.assertEqual(quote["turnover"], 123456789.0)
+        self.assertEqual(quote["source"], "kis-rest")
+        self.assertIsInstance(quote["ts"], int)
+
+        session.post.assert_called_once()
+        session.get.assert_called_once()
+
+        get_call_kwargs = session.get.call_args.kwargs
+        self.assertEqual(
+            get_call_kwargs["headers"]["authorization"], "Bearer token-123"
+        )
+        self.assertEqual(
+            get_call_kwargs["params"],
+            {"fid_cond_mrkt_div_code": "J", "fid_input_iscd": "005930"},
+        )
+
+    def test_token_is_cached_between_quote_requests(self):
+        session = MagicMock()
+
+        token_response = MagicMock()
+        token_response.json.return_value = {
+            "access_token": "token-123",
+            "expires_in": 3600,
+        }
+        token_response.raise_for_status.return_value = None
+
+        quote_response = MagicMock()
+        quote_response.json.return_value = {
+            "output": {
+                "stck_prpr": "100",
+                "prdy_ctrt": "0.1",
+                "acml_tr_pbmn": "200",
+            }
+        }
+        quote_response.raise_for_status.return_value = None
+
+        session.post.return_value = token_response
+        session.get.return_value = quote_response
+
+        client = KisRestClient(
+            app_key="app-key",
+            app_secret="app-secret",
+            env="mock",
+            session=session,
+            base_url="https://example.test",
+        )
+
+        client.get_quote("005930")
+        client.get_quote("000660")
+
+        self.assertEqual(session.post.call_count, 1)
+        self.assertEqual(session.get.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add KIS REST quote client (`app/integrations/kis_rest.py`)
- implement token issue/cache and quote retrieval mapping
- add client tests (`tests/test_kis_rest_client.py`)

## Verification
- python3 -m unittest tests/test_kis_rest_client.py -v
- python3 -m unittest discover -s tests -v
- result: 26 passed
