### PR TITLE
[Task3] Add KIS WS parser skeleton

### DIFF
--- a/app/integrations/kis_ws.py
+++ b/app/integrations/kis_ws.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, Callable, Dict, Optional
+
+
+def _to_float(value: Any, *, field_name: str) -> float:
+    try:
+        if value is None or value == "":
+            raise ValueError(f"missing value for {field_name}")
+        return float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"invalid numeric value for {field_name}: {value!r}") from exc
+
+
+def _to_float_default(value: Any, default: float = 0.0) -> float:
+    try:
+        if value is None or value == "":
+            return default
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def parse_message(payload: dict | str) -> Dict[str, Any]:
+    """Parse raw KIS WS payload into quote snapshot-compatible dict."""
+    raw: Dict[str, Any]
+
+    if isinstance(payload, str):
+        try:
+            decoded = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise ValueError("payload must be valid JSON string or dict") from exc
+        if not isinstance(decoded, dict):
+            raise ValueError("decoded payload must be an object")
+        raw = decoded
+    elif isinstance(payload, dict):
+        raw = payload
+    else:
+        raise ValueError("payload must be dict or JSON string")
+
+    symbol = (
+        raw.get("symbol")
+        or raw.get("fid_input_iscd")
+        or raw.get("stck_shrn_iscd")
+        or raw.get("code")
+    )
+    if not symbol:
+        raise ValueError("missing symbol in payload")
+
+    price_raw = raw.get("price")
+    if price_raw is None:
+        price_raw = raw.get("stck_prpr")
+    if price_raw is None:
+        price_raw = raw.get("last_price")
+    if price_raw is None:
+        raise ValueError("missing price in payload")
+
+    now = int(time.time())
+
+    return {
+        "symbol": str(symbol),
+        "price": _to_float(price_raw, field_name="price"),
+        "change_pct": _to_float_default(
+            raw.get("change_pct", raw.get("prdy_ctrt", raw.get("chg_rate"))),
+            default=0.0,
+        ),
+        "turnover": _to_float_default(
+            raw.get("turnover", raw.get("acml_tr_pbmn", raw.get("acc_trade_value"))),
+            default=0.0,
+        ),
+        "source": str(raw.get("source", "kis-ws")),
+        "ts": int(raw.get("ts", now)),
+        "freshness_sec": float(raw.get("freshness_sec", 0.0)),
+        "state": str(raw.get("state", "HEALTHY")),
+    }
+
+
+class KisWsClient:
+    """KIS websocket client skeleton (network connection intentionally omitted)."""
+
+    def __init__(self, on_message: Optional[Callable[[Dict[str, Any]], None]] = None) -> None:
+        self._on_message = on_message
+        self.running = False
+
+    def start(self) -> None:
+        self.running = True
+
+    def stop(self) -> None:
+        self.running = False
+
+    def set_on_message(self, callback: Callable[[Dict[str, Any]], None]) -> None:
+        self._on_message = callback
+
+    def handle_raw_message(self, payload: dict | str) -> Dict[str, Any]:
+        quote = parse_message(payload)
+        if self._on_message is not None:
+            self._on_message(quote)
+        return quote

--- a/tests/test_kis_ws_parser.py
+++ b/tests/test_kis_ws_parser.py
@@ -1,0 +1,82 @@
+import unittest
+
+from app.integrations.kis_ws import KisWsClient, parse_message
+
+
+class TestKisWsParser(unittest.TestCase):
+    def test_parse_message_maps_kis_style_fields(self):
+        payload = {
+            "fid_input_iscd": "005930",
+            "stck_prpr": "71200",
+            "prdy_ctrt": "1.35",
+            "acml_tr_pbmn": "123456789",
+        }
+
+        parsed = parse_message(payload)
+
+        self.assertEqual(parsed["symbol"], "005930")
+        self.assertEqual(parsed["price"], 71200.0)
+        self.assertEqual(parsed["change_pct"], 1.35)
+        self.assertEqual(parsed["turnover"], 123456789.0)
+        self.assertEqual(parsed["source"], "kis-ws")
+        self.assertEqual(parsed["state"], "HEALTHY")
+        self.assertEqual(parsed["freshness_sec"], 0.0)
+        self.assertIsInstance(parsed["ts"], int)
+
+    def test_parse_message_maps_normalized_fields(self):
+        payload = {
+            "symbol": "000660",
+            "price": "198500",
+            "change_pct": "-0.52",
+            "turnover": "987654321",
+            "source": "kis-ws-stream",
+            "ts": 1700000000,
+        }
+
+        parsed = parse_message(payload)
+
+        self.assertEqual(parsed["symbol"], "000660")
+        self.assertEqual(parsed["price"], 198500.0)
+        self.assertEqual(parsed["change_pct"], -0.52)
+        self.assertEqual(parsed["turnover"], 987654321.0)
+        self.assertEqual(parsed["source"], "kis-ws-stream")
+        self.assertEqual(parsed["ts"], 1700000000)
+
+    def test_parse_message_raises_for_invalid_payload(self):
+        with self.assertRaises(ValueError):
+            parse_message("not-json")
+
+        with self.assertRaises(ValueError):
+            parse_message({"price": "1000"})
+
+        with self.assertRaises(ValueError):
+            parse_message({"symbol": "005930"})
+
+    def test_client_start_stop_and_on_message_hook(self):
+        received = []
+
+        client = KisWsClient(on_message=lambda quote: received.append(quote))
+        self.assertFalse(client.running)
+
+        client.start()
+        self.assertTrue(client.running)
+
+        output = client.handle_raw_message(
+            {
+                "symbol": "005930",
+                "price": "70000",
+                "change_pct": "0.0",
+                "turnover": "100",
+            }
+        )
+
+        self.assertEqual(output["symbol"], "005930")
+        self.assertEqual(len(received), 1)
+        self.assertEqual(received[0]["symbol"], "005930")
+
+        client.stop()
+        self.assertFalse(client.running)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add KIS WS parser skeleton (`app/integrations/kis_ws.py`)
- add `KisWsClient` start/stop/on_message hook interfaces
- add parser regression tests (`tests/test_kis_ws_parser.py`)

## Verification
- python3 -m unittest tests/test_kis_ws_parser.py -v
- python3 -m unittest discover -s tests -v
- result: 30 passed
