### PR TITLE
[Task4] Add market hours policy

### DIFF
--- a/app/services/market_hours.py
+++ b/app/services/market_hours.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from datetime import datetime, time
+from zoneinfo import ZoneInfo
+
+KST = ZoneInfo("Asia/Seoul")
+MARKET_OPEN_TIME = time(9, 0)
+MARKET_CLOSE_TIME = time(15, 30)
+
+
+def is_market_open(now: datetime | None = None) -> bool:
+    """Return whether KRX market session is open in Asia/Seoul time."""
+    current = now or datetime.now(KST)
+
+    if current.tzinfo is None:
+        seoul_now = current.replace(tzinfo=KST)
+    else:
+        seoul_now = current.astimezone(KST)
+
+    current_time = seoul_now.time()
+    return MARKET_OPEN_TIME <= current_time < MARKET_CLOSE_TIME

--- a/tests/test_market_hours.py
+++ b/tests/test_market_hours.py
@@ -1,0 +1,19 @@
+import unittest
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from app.services.market_hours import is_market_open
+
+
+class TestMarketHoursPolicy(unittest.TestCase):
+    def test_market_open_at_10am_seoul(self):
+        dt = datetime(2026, 1, 2, 10, 0, tzinfo=ZoneInfo("Asia/Seoul"))
+        self.assertTrue(is_market_open(dt))
+
+    def test_market_closed_at_8pm_seoul(self):
+        dt = datetime(2026, 1, 2, 20, 0, tzinfo=ZoneInfo("Asia/Seoul"))
+        self.assertFalse(is_market_open(dt))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add market hours policy service (`app/services/market_hours.py`)
- add deterministic tests for in-session/out-of-session (`tests/test_market_hours.py`)

## Verification
- python3 -m unittest tests/test_market_hours.py -v
- python3 -m unittest discover -s tests -v
- result: 32 passed
