### PR TITLE
[Task5] Add quote gateway ws/rest fallback service

### DIFF
--- a/app/services/quote_gateway.py
+++ b/app/services/quote_gateway.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import time
+from typing import Callable
+
+from app.schemas.quote import QuoteSnapshot
+from app.services.market_hours import is_market_open
+from app.services.quote_cache import QuoteCache
+
+
+class QuoteGatewayService:
+    """WS-first quote source selector with REST fallback."""
+
+    def __init__(
+        self,
+        *,
+        quote_cache: QuoteCache,
+        rest_client,
+        market_open_checker: Callable | None = None,
+        stale_after_sec: int = 5,
+    ) -> None:
+        self.quote_cache = quote_cache
+        self.rest_client = rest_client
+        self.market_open_checker = market_open_checker or is_market_open
+        self.stale_after_sec = stale_after_sec
+        self.rest_fallbacks = 0
+
+    def _is_fresh(self, snapshot: QuoteSnapshot, now: int) -> bool:
+        age = float(max(now - snapshot.ts, 0))
+        snapshot.freshness_sec = age
+        snapshot.state = "HEALTHY" if age <= self.stale_after_sec else "STALE"
+        return age <= self.stale_after_sec
+
+    def _fetch_rest(self, symbol: str) -> QuoteSnapshot:
+        self.rest_fallbacks += 1
+        payload = self.rest_client.get_quote(symbol)
+        now = int(time.time())
+        return QuoteSnapshot(
+            symbol=str(payload["symbol"]),
+            price=float(payload["price"]),
+            change_pct=float(payload.get("change_pct", 0.0)),
+            turnover=float(payload.get("turnover", 0.0)),
+            source=str(payload.get("source", "kis-rest")),
+            ts=int(payload.get("ts", now)),
+            freshness_sec=0.0,
+            state="HEALTHY",
+        )
+
+    def get_quote(self, symbol: str) -> QuoteSnapshot:
+        now = int(time.time())
+        if self.market_open_checker():
+            cached = self.quote_cache.get(symbol)
+            if cached is not None and self._is_fresh(cached, now):
+                return cached
+            return self._fetch_rest(symbol)
+        return self._fetch_rest(symbol)
+
+    def metrics(self) -> dict[str, int]:
+        return {"rest_fallbacks": self.rest_fallbacks}

--- a/tests/test_quote_gateway_service.py
+++ b/tests/test_quote_gateway_service.py
@@ -1,0 +1,108 @@
+import time
+import unittest
+
+from app.schemas.quote import QuoteSnapshot
+from app.services.quote_cache import QuoteCache
+from app.services.quote_gateway import QuoteGatewayService
+
+
+class StubRestClient:
+    def __init__(self, payload: dict) -> None:
+        self.payload = payload
+        self.calls = 0
+
+    def get_quote(self, symbol: str) -> dict:
+        self.calls += 1
+        data = dict(self.payload)
+        data["symbol"] = symbol
+        return data
+
+
+class QuoteGatewayServiceTest(unittest.TestCase):
+    def test_market_open_with_fresh_ws_cache_uses_ws(self):
+        cache = QuoteCache()
+        cache.upsert(
+            QuoteSnapshot(
+                symbol="005930",
+                price=71000.0,
+                change_pct=0.1,
+                turnover=100.0,
+                source="kis-ws",
+                ts=int(time.time()),
+                freshness_sec=0.0,
+                state="HEALTHY",
+            )
+        )
+        rest_client = StubRestClient({"price": 70000.0, "source": "kis-rest", "ts": int(time.time())})
+        service = QuoteGatewayService(
+            quote_cache=cache,
+            rest_client=rest_client,
+            market_open_checker=lambda: True,
+            stale_after_sec=5,
+        )
+
+        quote = service.get_quote("005930")
+
+        self.assertEqual(quote.source, "kis-ws")
+        self.assertEqual(rest_client.calls, 0)
+        self.assertEqual(service.metrics()["rest_fallbacks"], 0)
+
+    def test_market_open_with_stale_ws_cache_falls_back_to_rest(self):
+        cache = QuoteCache()
+        cache.upsert(
+            QuoteSnapshot(
+                symbol="005930",
+                price=71000.0,
+                change_pct=0.1,
+                turnover=100.0,
+                source="kis-ws",
+                ts=int(time.time()) - 10,
+                freshness_sec=0.0,
+                state="HEALTHY",
+            )
+        )
+        rest_client = StubRestClient({
+            "price": 70900.0,
+            "change_pct": 0.05,
+            "turnover": 110.0,
+            "source": "kis-rest",
+            "ts": int(time.time()),
+        })
+        service = QuoteGatewayService(
+            quote_cache=cache,
+            rest_client=rest_client,
+            market_open_checker=lambda: True,
+            stale_after_sec=5,
+        )
+
+        quote = service.get_quote("005930")
+
+        self.assertEqual(quote.source, "kis-rest")
+        self.assertEqual(rest_client.calls, 1)
+        self.assertEqual(service.metrics()["rest_fallbacks"], 1)
+
+    def test_market_closed_uses_rest(self):
+        cache = QuoteCache()
+        rest_client = StubRestClient({
+            "price": 70500.0,
+            "change_pct": -0.2,
+            "turnover": 80.0,
+            "source": "kis-rest",
+            "ts": int(time.time()),
+        })
+        service = QuoteGatewayService(
+            quote_cache=cache,
+            rest_client=rest_client,
+            market_open_checker=lambda: False,
+            stale_after_sec=5,
+        )
+
+        quote = service.get_quote("005930")
+
+        self.assertEqual(quote.source, "kis-rest")
+        self.assertEqual(rest_client.calls, 1)
+        self.assertEqual(service.metrics()["rest_fallbacks"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `QuoteGatewayService` with WS-first / REST-fallback policy
- add fallback metrics counter in service layer
- add service tests for open/fresh, open/stale fallback, closed/rest scenarios

## Verification
- python3 -m unittest tests/test_quote_gateway_service.py -v
- python3 -m unittest discover -s tests -v
- result: 35 passed
