### PR TITLE
[Task7] Manage WS lifecycle on app startup/shutdown

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import time
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
 from app.api.routes import router
 from app.config.settings import get_settings
-from app.services.quote_cache import quote_cache
+from app.integrations.kis_ws import KisWsClient
+from app.services.quote_cache import quote_cache, quote_ingest_worker
 from app.services.quote_gateway import QuoteGatewayService
 
 
@@ -22,11 +24,21 @@ class _DemoRestQuoteClient:
         }
 
 
-app = FastAPI(title="KIS Trading Gateway", version="0.1.0")
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    app.state.ws_client.start()
+    try:
+        yield
+    finally:
+        app.state.ws_client.stop()
+
+
+app = FastAPI(title="KIS Trading Gateway", version="0.1.0", lifespan=lifespan)
 app.include_router(router, prefix="/v1")
 
 # NOTE: lazy-loaded so app import does not require env during tests.
 app.state.get_settings = get_settings
+app.state.ws_client = KisWsClient(on_message=quote_ingest_worker.on_ws_message)
 app.state.quote_gateway_service = QuoteGatewayService(
     quote_cache=quote_cache,
     rest_client=_DemoRestQuoteClient(),

--- a/tests/test_app_lifecycle_ws.py
+++ b/tests/test_app_lifecycle_ws.py
@@ -1,0 +1,31 @@
+import unittest
+from unittest.mock import Mock
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+class AppLifecycleWsTest(unittest.TestCase):
+    def test_ws_client_start_stop_on_app_lifecycle(self):
+        ws_client = app.state.ws_client
+        original_start = ws_client.start
+        original_stop = ws_client.stop
+
+        start_mock = Mock()
+        stop_mock = Mock()
+        ws_client.start = start_mock
+        ws_client.stop = stop_mock
+
+        try:
+            with TestClient(app):
+                start_mock.assert_called_once_with()
+                stop_mock.assert_not_called()
+            stop_mock.assert_called_once_with()
+        finally:
+            ws_client.start = original_start
+            ws_client.stop = original_stop
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add app lifecycle management for WS client
- startup triggers ws_client.start()
- shutdown triggers ws_client.stop()
- add deterministic lifecycle test

## Verification
- python3 -m unittest tests/test_app_lifecycle_ws.py -v
- python3 -m unittest discover -s tests -v
- result: 38 passed
