### PR TITLE
[Task8] Add quote pipeline operational metrics

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -107,8 +107,11 @@ def get_order_status(order_id: str):
 
 
 @router.get('/metrics/quote')
-def quote_metrics():
-    return quote_ingest_worker.metrics()
+def quote_metrics(request: Request):
+    metrics = quote_ingest_worker.metrics()
+    service = request.app.state.quote_gateway_service
+    metrics.update(service.metrics())
+    return metrics
 
 
 @router.get('/metrics/order')

--- a/app/services/quote_cache.py
+++ b/app/services/quote_cache.py
@@ -35,6 +35,8 @@ class QuoteIngestWorker:
         self.stale_after_sec = stale_after_sec
         self.ws_messages = 0
         self.upserts = 0
+        self.ws_connected = False
+        self.last_ws_message_ts: int | None = None
 
     def on_ws_message(self, payload: dict) -> QuoteSnapshot:
         now = int(time.time())
@@ -51,6 +53,8 @@ class QuoteIngestWorker:
         self.cache.upsert(snapshot)
         self.ws_messages += 1
         self.upserts += 1
+        self.ws_connected = True
+        self.last_ws_message_ts = snapshot.ts
         return snapshot
 
     def refresh_freshness(self, now: int | None = None) -> None:
@@ -69,6 +73,8 @@ class QuoteIngestWorker:
             "ws_messages": self.ws_messages,
             "upserts": self.upserts,
             "stale_symbols": stale,
+            "ws_connected": self.ws_connected,
+            "last_ws_message_ts": self.last_ws_message_ts,
         }
 
 

--- a/tests/test_quote_metrics_extended.py
+++ b/tests/test_quote_metrics_extended.py
@@ -1,0 +1,55 @@
+import unittest
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.services.quote_cache import quote_cache, quote_ingest_worker
+
+
+class QuoteMetricsExtendedTest(unittest.TestCase):
+    def setUp(self):
+        quote_cache._rows.clear()
+        quote_ingest_worker.ws_messages = 0
+        quote_ingest_worker.upserts = 0
+        quote_ingest_worker.ws_connected = False
+        quote_ingest_worker.last_ws_message_ts = None
+
+        app.state.quote_gateway_service.rest_fallbacks = 0
+        app.state.quote_gateway_service.market_open_checker = lambda: False
+        self.client = TestClient(app)
+
+    def test_quote_metrics_contains_operational_fields(self):
+        res = self.client.get('/v1/metrics/quote')
+        self.assertEqual(res.status_code, 200)
+        payload = res.json()
+
+        self.assertIn('cached_symbols', payload)
+        self.assertIn('ws_messages', payload)
+        self.assertIn('upserts', payload)
+        self.assertIn('stale_symbols', payload)
+
+        self.assertIn('rest_fallbacks', payload)
+        self.assertIn('ws_connected', payload)
+        self.assertIn('last_ws_message_ts', payload)
+
+        self.assertEqual(payload['rest_fallbacks'], 0)
+        self.assertFalse(payload['ws_connected'])
+        self.assertIsNone(payload['last_ws_message_ts'])
+
+    def test_quote_metrics_updates_after_ws_and_rest_fallback(self):
+        app.state.quote_gateway_service.get_quote('005930')
+        quote_ingest_worker.on_ws_message({'symbol': '005930', 'price': 70100, 'ts': 1700000000})
+
+        res = self.client.get('/v1/metrics/quote')
+        self.assertEqual(res.status_code, 200)
+        payload = res.json()
+
+        self.assertEqual(payload['rest_fallbacks'], 1)
+        self.assertEqual(payload['ws_messages'], 1)
+        self.assertEqual(payload['upserts'], 1)
+        self.assertTrue(payload['ws_connected'])
+        self.assertEqual(payload['last_ws_message_ts'], 1700000000)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend quote pipeline metrics for ops visibility
- add fields: `rest_fallbacks`, `ws_connected`, `last_ws_message_ts`
- keep existing quote metrics keys backward-compatible
- add regression tests for extended metrics payload

## Verification
- python3 -m unittest tests/test_quote_metrics_extended.py -v
- python3 -m unittest discover -s tests -v
- result: 40 passed
