### PR TITLE
[RealConn-Task1] Align KIS REST token contract

### DIFF
--- a/tests/test_kis_rest_client.py
+++ b/tests/test_kis_rest_client.py
@@ -1,10 +1,42 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from app.integrations.kis_rest import KisRestClient
 
 
 class TestKisRestClient(unittest.TestCase):
+    def test_issue_token_uses_kis_contract(self):
+        session = MagicMock()
+
+        token_response = MagicMock()
+        token_response.json.return_value = {
+            "access_token": "token-123",
+            "expires_in": 3600,
+        }
+        token_response.raise_for_status.return_value = None
+        session.post.return_value = token_response
+
+        client = KisRestClient(
+            app_key="app-key",
+            app_secret="app-secret",
+            env="mock",
+            session=session,
+            base_url="https://example.test",
+        )
+
+        client.get_access_token()
+
+        session.post.assert_called_once_with(
+            "https://example.test/oauth2/tokenP",
+            headers={"content-type": "application/json; charset=utf-8"},
+            json={
+                "grant_type": "client_credentials",
+                "appkey": "app-key",
+                "appsecret": "app-secret",
+            },
+            timeout=5,
+        )
+
     def test_get_quote_parses_response_and_auth_flow(self):
         session = MagicMock()
 
@@ -93,6 +125,41 @@ class TestKisRestClient(unittest.TestCase):
 
         self.assertEqual(session.post.call_count, 1)
         self.assertEqual(session.get.call_count, 2)
+
+    def test_short_ttl_token_is_still_cached_briefly(self):
+        session = MagicMock()
+
+        first_token_response = MagicMock()
+        first_token_response.json.return_value = {
+            "access_token": "token-123",
+            "expires_in": 30,
+        }
+        first_token_response.raise_for_status.return_value = None
+
+        second_token_response = MagicMock()
+        second_token_response.json.return_value = {
+            "access_token": "token-456",
+            "expires_in": 30,
+        }
+        second_token_response.raise_for_status.return_value = None
+
+        session.post.side_effect = [first_token_response, second_token_response]
+
+        client = KisRestClient(
+            app_key="app-key",
+            app_secret="app-secret",
+            env="mock",
+            session=session,
+            base_url="https://example.test",
+        )
+
+        with patch("app.integrations.kis_rest.time.time", side_effect=[1000.0, 1000.2]):
+            token1 = client.get_access_token()
+            token2 = client.get_access_token()
+
+        self.assertEqual(token1, "token-123")
+        self.assertEqual(token2, "token-123")
+        self.assertEqual(session.post.call_count, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- align KIS auth token request contract in REST integration
- add contract test for token endpoint/header/body behavior
- add token cache boundary test for short TTL behavior

## Verification
- python3 -m unittest tests/test_kis_rest_client.py -v
- python3 -m unittest discover -s tests -v
- result: 45 passed
