### PR TITLE
[Task2] KIS WS contract alignment

### DIFF
--- a/app/integrations/kis_ws.py
+++ b/app/integrations/kis_ws.py
@@ -40,20 +40,25 @@ def parse_message(payload: dict | str) -> Dict[str, Any]:
     else:
         raise ValueError("payload must be dict or JSON string")
 
+    body = raw.get("body")
+    nested_output = body.get("output") if isinstance(body, dict) else None
+    normalized = {**raw, **nested_output} if isinstance(nested_output, dict) else raw
+
     symbol = (
-        raw.get("symbol")
-        or raw.get("fid_input_iscd")
-        or raw.get("stck_shrn_iscd")
-        or raw.get("code")
+        normalized.get("symbol")
+        or normalized.get("fid_input_iscd")
+        or normalized.get("stck_shrn_iscd")
+        or normalized.get("mksc_shrn_iscd")
+        or normalized.get("code")
     )
     if not symbol:
         raise ValueError("missing symbol in payload")
 
-    price_raw = raw.get("price")
+    price_raw = normalized.get("price")
     if price_raw is None:
-        price_raw = raw.get("stck_prpr")
+        price_raw = normalized.get("stck_prpr")
     if price_raw is None:
-        price_raw = raw.get("last_price")
+        price_raw = normalized.get("last_price")
     if price_raw is None:
         raise ValueError("missing price in payload")
 
@@ -63,26 +68,40 @@ def parse_message(payload: dict | str) -> Dict[str, Any]:
         "symbol": str(symbol),
         "price": _to_float(price_raw, field_name="price"),
         "change_pct": _to_float_default(
-            raw.get("change_pct", raw.get("prdy_ctrt", raw.get("chg_rate"))),
+            normalized.get("change_pct", normalized.get("prdy_ctrt", normalized.get("chg_rate"))),
             default=0.0,
         ),
         "turnover": _to_float_default(
-            raw.get("turnover", raw.get("acml_tr_pbmn", raw.get("acc_trade_value"))),
+            normalized.get("turnover", normalized.get("acml_tr_pbmn", normalized.get("acc_trade_value"))),
             default=0.0,
         ),
-        "source": str(raw.get("source", "kis-ws")),
-        "ts": int(raw.get("ts", now)),
-        "freshness_sec": float(raw.get("freshness_sec", 0.0)),
-        "state": str(raw.get("state", "HEALTHY")),
+        "source": str(normalized.get("source", "kis-ws")),
+        "ts": int(normalized.get("ts", now)),
+        "freshness_sec": float(normalized.get("freshness_sec", 0.0)),
+        "state": str(normalized.get("state", "HEALTHY")),
     }
 
 
 class KisWsClient:
     """KIS websocket client skeleton (network connection intentionally omitted)."""
 
-    def __init__(self, on_message: Optional[Callable[[Dict[str, Any]], None]] = None) -> None:
+    def __init__(
+        self,
+        on_message: Optional[Callable[[Dict[str, Any]], None]] = None,
+        *,
+        approval_key: str = "",
+        tr_id: str = "H0STCNT0",
+        custtype: str = "P",
+        tr_type: str = "1",
+        content_type: str = "utf-8",
+    ) -> None:
         self._on_message = on_message
         self.running = False
+        self.approval_key = approval_key
+        self.tr_id = tr_id
+        self.custtype = custtype
+        self.tr_type = tr_type
+        self.content_type = content_type
 
     def start(self) -> None:
         self.running = True
@@ -92,6 +111,22 @@ class KisWsClient:
 
     def set_on_message(self, callback: Callable[[Dict[str, Any]], None]) -> None:
         self._on_message = callback
+
+    def build_subscribe_message(self, symbol: str) -> Dict[str, Any]:
+        return {
+            "header": {
+                "approval_key": self.approval_key,
+                "custtype": self.custtype,
+                "tr_type": self.tr_type,
+                "content-type": self.content_type,
+            },
+            "body": {
+                "input": {
+                    "tr_id": self.tr_id,
+                    "tr_key": symbol,
+                }
+            },
+        }
 
     def handle_raw_message(self, payload: dict | str) -> Dict[str, Any]:
         quote = parse_message(payload)


### PR DESCRIPTION
## Scope
- Added WS parser contract tests for real KIS notice envelope (`body.output`) mapping to normalized quote fields.
- Added subscribe request contract test for KIS websocket header/body payload shape.
- Implemented minimal parser normalization and `build_subscribe_message` in `KisWsClient`.

## RED evidence
- Command: `python3 -m unittest tests/test_kis_ws_parser.py -v`
- Key failures:
  - `TypeError: KisWsClient.__init__() got an unexpected keyword argument 'approval_key'`
  - `ValueError: missing symbol in payload` (real KIS notice format test)

## GREEN evidence
- Command: `python3 -m unittest tests/test_kis_ws_parser.py -v`
- Result: `Ran 6 tests ... OK`

## Full regression
- Command: `python3 -m unittest discover -s tests -v`
- Result: `Ran 45 tests ... OK`

## Risks
- Current parser contract handles dict/JSON envelope with `body.output`; raw pipe-delimited KIS frames are not introduced in this task.
- Subscribe payload defaults (`tr_id=H0STCNT0`, `custtype=P`, `tr_type=1`) are set for current domestic quote flow and may need extension for other channels.
