### PR TITLE
[Task4] WS reconnect backoff policy

### DIFF
--- a/tests/test_kis_ws_reconnect.py
+++ b/tests/test_kis_ws_reconnect.py
@@ -1,0 +1,53 @@
+import unittest
+
+from app.integrations.kis_ws import KisWsClient
+
+
+class TestKisWsReconnect(unittest.TestCase):
+    def test_reconnect_uses_exponential_backoff_sequence(self):
+        client = KisWsClient()
+        sleeps = []
+        attempts = []
+
+        def connect_once():
+            attempts.append("x")
+            raise RuntimeError("disconnect")
+
+        result = client.run_with_reconnect(
+            connect_once=connect_once,
+            sleep_fn=lambda sec: sleeps.append(sec),
+            max_retries=3,
+            backoff_base_sec=1.0,
+            backoff_cap_sec=10.0,
+        )
+
+        self.assertFalse(result)
+        self.assertEqual(len(attempts), 3)
+        self.assertEqual(sleeps, [1.0, 2.0, 4.0])
+
+    def test_stop_signal_exits_reconnect_loop_immediately(self):
+        client = KisWsClient()
+        client.start()
+        calls = {"count": 0}
+
+        def connect_once():
+            calls["count"] += 1
+            client.stop()
+            raise RuntimeError("disconnect")
+
+        sleeps = []
+        result = client.run_with_reconnect(
+            connect_once=connect_once,
+            sleep_fn=lambda sec: sleeps.append(sec),
+            max_retries=5,
+            backoff_base_sec=1.0,
+            backoff_cap_sec=10.0,
+        )
+
+        self.assertFalse(result)
+        self.assertEqual(calls["count"], 1)
+        self.assertEqual(sleeps, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add reconnect loop API to KisWsClient with exponential backoff
- support immediate stop via running flag during reconnect loop
- track last_error and reconnect_count in client state
- add unit tests for backoff sequence and stop-signal behavior

## Verification
- python3 -m unittest tests/test_kis_ws_reconnect.py -v