### PR TITLE
[Task5] REST fallback rate-limit guard

### DIFF
--- a/app/services/quote_gateway.py
+++ b/app/services/quote_gateway.py
@@ -18,12 +18,15 @@ class QuoteGatewayService:
         rest_client,
         market_open_checker: Callable | None = None,
         stale_after_sec: int = 5,
+        rest_cooldown_sec: int = 3,
     ) -> None:
         self.quote_cache = quote_cache
         self.rest_client = rest_client
         self.market_open_checker = market_open_checker or is_market_open
         self.stale_after_sec = stale_after_sec
+        self.rest_cooldown_sec = rest_cooldown_sec
         self.rest_fallbacks = 0
+        self._rest_symbol_cooldown_until: dict[str, int] = {}
 
     def _is_fresh(self, snapshot: QuoteSnapshot, now: int) -> bool:
         age = float(max(now - snapshot.ts, 0))
@@ -31,10 +34,34 @@ class QuoteGatewayService:
         snapshot.state = "HEALTHY" if age <= self.stale_after_sec else "STALE"
         return age <= self.stale_after_sec
 
-    def _fetch_rest(self, symbol: str) -> QuoteSnapshot:
+    def _is_symbol_cooldown(self, symbol: str, now: int) -> bool:
+        until = self._rest_symbol_cooldown_until.get(symbol, 0)
+        return now < until
+
+    def _mark_symbol_cooldown(self, symbol: str, now: int) -> None:
+        self._rest_symbol_cooldown_until[symbol] = now + self.rest_cooldown_sec
+
+    @staticmethod
+    def _status_code_from_error(exc: Exception) -> int | None:
+        response = getattr(exc, "response", None)
+        code = getattr(response, "status_code", None)
+        if isinstance(code, int):
+            return code
+        return None
+
+    def _fetch_rest(self, symbol: str, now: int) -> QuoteSnapshot:
         self.rest_fallbacks += 1
-        payload = self.rest_client.get_quote(symbol)
-        now = int(time.time())
+        try:
+            payload = self.rest_client.get_quote(symbol)
+        except Exception as exc:
+            if self._status_code_from_error(exc) == 429:
+                self._mark_symbol_cooldown(symbol, now)
+                cached = self.quote_cache.get(symbol)
+                if cached is not None:
+                    self._is_fresh(cached, now)
+                    return cached
+                raise RuntimeError("REST_RATE_LIMIT_COOLDOWN") from exc
+            raise
         return QuoteSnapshot(
             symbol=str(payload["symbol"]),
             price=float(payload["price"]),
@@ -48,12 +75,19 @@ class QuoteGatewayService:
 
     def get_quote(self, symbol: str) -> QuoteSnapshot:
         now = int(time.time())
+        if self._is_symbol_cooldown(symbol, now):
+            cached = self.quote_cache.get(symbol)
+            if cached is not None:
+                self._is_fresh(cached, now)
+                return cached
+            raise RuntimeError("REST_RATE_LIMIT_COOLDOWN")
+
         if self.market_open_checker():
             cached = self.quote_cache.get(symbol)
             if cached is not None and self._is_fresh(cached, now):
                 return cached
-            return self._fetch_rest(symbol)
-        return self._fetch_rest(symbol)
+            return self._fetch_rest(symbol, now)
+        return self._fetch_rest(symbol, now)
 
     def metrics(self) -> dict[str, int]:
         return {"rest_fallbacks": self.rest_fallbacks}

--- a/tests/test_quote_gateway_service.py
+++ b/tests/test_quote_gateway_service.py
@@ -18,6 +18,23 @@ class StubRestClient:
         return data
 
 
+class RateLimitRestClient:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def get_quote(self, symbol: str) -> dict:
+        self.calls += 1
+
+        class Response:
+            status_code = 429
+
+        class RateLimitError(Exception):
+            def __init__(self):
+                self.response = Response()
+
+        raise RateLimitError()
+
+
 class QuoteGatewayServiceTest(unittest.TestCase):
     def test_market_open_with_fresh_ws_cache_uses_ws(self):
         cache = QuoteCache()
@@ -102,6 +119,54 @@ class QuoteGatewayServiceTest(unittest.TestCase):
         self.assertEqual(quote.source, "kis-rest")
         self.assertEqual(rest_client.calls, 1)
         self.assertEqual(service.metrics()["rest_fallbacks"], 1)
+
+    def test_rate_limit_cooldown_suppresses_repeated_fallback_same_symbol(self):
+        cache = QuoteCache()
+        stale_ts = int(time.time()) - 20
+        cache.upsert(
+            QuoteSnapshot(
+                symbol="005930",
+                price=70000.0,
+                change_pct=0.0,
+                turnover=10.0,
+                source="kis-ws",
+                ts=stale_ts,
+                freshness_sec=0.0,
+                state="STALE",
+            )
+        )
+        rest_client = RateLimitRestClient()
+        service = QuoteGatewayService(
+            quote_cache=cache,
+            rest_client=rest_client,
+            market_open_checker=lambda: True,
+            stale_after_sec=5,
+        )
+
+        quote1 = service.get_quote("005930")
+        quote2 = service.get_quote("005930")
+
+        self.assertEqual(rest_client.calls, 1)
+        self.assertEqual(quote1.source, "kis-ws")
+        self.assertEqual(quote2.source, "kis-ws")
+
+    def test_rate_limit_without_cache_raises_cooldown_error(self):
+        cache = QuoteCache()
+        rest_client = RateLimitRestClient()
+        service = QuoteGatewayService(
+            quote_cache=cache,
+            rest_client=rest_client,
+            market_open_checker=lambda: False,
+            stale_after_sec=5,
+        )
+
+        with self.assertRaises(RuntimeError):
+            service.get_quote("000660")
+
+        with self.assertRaises(RuntimeError):
+            service.get_quote("000660")
+
+        self.assertEqual(rest_client.calls, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add REST fallback cooldown per symbol to suppress repeated calls after 429
- when cooldown is active, return cached quote if available, otherwise raise REST_RATE_LIMIT_COOLDOWN
- on 429 response, mark cooldown and avoid immediate repeated fallback storms
- add tests for same-symbol suppression and cooldown error path without cache

## Verification
- python3 -m unittest tests/test_quote_gateway_service.py -v