### PR TITLE
[Task7] Finalize ops checklist/runbook for real connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,17 @@ curl -s http://127.0.0.1:8890/v1/metrics/quote | jq
 ```
 - startup 시 WS client start, shutdown 시 stop 수행
 - `rest_fallbacks`, `ws_connected`, `last_ws_message_ts`를 운영 지표로 확인
+- `ws_heartbeat_fresh`, `ws_reconnect_count`, `ws_last_error`로 reconnect 상태를 함께 점검
+- REST 429 발생 시 `REST_RATE_LIMIT_COOLDOWN`(HTTP 503) 응답 정책 확인
 
 ### 장중/장외 동작 기대치
 - 장중(09:00~15:30 KST): WS fresh면 `kis-ws`, stale/미수신이면 `kis-rest`
 - 장외: `kis-rest`
 
 ### 장애 대응 핵심
-- WS 끊김: metrics 확인 → 프로세스 재기동 → WS 지표 회복 확인
-- REST rate limit: 조회 빈도 축소, 백오프/재시도, 한도/권한 점검
+- WS 끊김(reconnect): metrics 확인 → 프로세스 재기동/재연결 → `ws_connected`, `ws_heartbeat_fresh`, `ws_reconnect_count` 회복 확인
+- REST rate limit(429): 조회 빈도 축소, 백오프/재시도, `REST_RATE_LIMIT_COOLDOWN` 처리 확인
+- 인증(token): 토큰 발급/갱신 실패 시 APP_KEY/APP_SECRET 및 환경(mock/live) 재확인
 
 상세 운영 절차: `docs/ops/kis-quote-runbook.md`
 


### PR DESCRIPTION
## Summary
- update README operational section with reconnect/heartbeat/rate-limit(429)/token checks
- update runbook with ws health keys, 429 cooldown behavior, and token incident response checklist
- align docs to current metrics and quote API behavior

## Verification
- rg -n "reconnect|429|token|ws_connected|last_ws_message_ts" README.md docs/ops/kis-quote-runbook.md