### PR TITLE
[Hardening T1] Typed cooldown exception mapping

### DIFF
--- a/app/errors.py
+++ b/app/errors.py
@@ -1,0 +1,3 @@
+class RestRateLimitCooldownError(RuntimeError):
+    """Raised when REST quote fallback is suppressed due to recent 429 cooldown."""
+

--- a/app/services/quote_gateway.py
+++ b/app/services/quote_gateway.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import time
 from typing import Callable
 
+from app.errors import RestRateLimitCooldownError
 from app.schemas.quote import QuoteSnapshot
 from app.services.market_hours import is_market_open
 from app.services.quote_cache import QuoteCache
@@ -60,7 +61,7 @@ class QuoteGatewayService:
                 if cached is not None:
                     self._is_fresh(cached, now)
                     return cached
-                raise RuntimeError("REST_RATE_LIMIT_COOLDOWN") from exc
+                raise RestRateLimitCooldownError("REST_RATE_LIMIT_COOLDOWN") from exc
             raise
         return QuoteSnapshot(
             symbol=str(payload["symbol"]),
@@ -80,7 +81,7 @@ class QuoteGatewayService:
             if cached is not None:
                 self._is_fresh(cached, now)
                 return cached
-            raise RuntimeError("REST_RATE_LIMIT_COOLDOWN")
+            raise RestRateLimitCooldownError("REST_RATE_LIMIT_COOLDOWN")
 
         if self.market_open_checker():
             cached = self.quote_cache.get(symbol)

--- a/tests/test_quote_gateway_service.py
+++ b/tests/test_quote_gateway_service.py
@@ -3,6 +3,7 @@ import unittest
 
 from app.schemas.quote import QuoteSnapshot
 from app.services.quote_cache import QuoteCache
+from app.errors import RestRateLimitCooldownError
 from app.services.quote_gateway import QuoteGatewayService
 
 
@@ -160,10 +161,10 @@ class QuoteGatewayServiceTest(unittest.TestCase):
             stale_after_sec=5,
         )
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(RestRateLimitCooldownError):
             service.get_quote("000660")
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(RestRateLimitCooldownError):
             service.get_quote("000660")
 
         self.assertEqual(rest_client.calls, 1)


### PR DESCRIPTION
## Summary
- add RestRateLimitCooldownError typed exception
- replace string-based RuntimeError checks in quote gateway/routes
- keep HTTP 503 mapping behavior for cooldown path

## Verification
- python3 -m unittest tests/test_quote_gateway_service.py tests/test_quote_e2e_mock_kis.py -v