### PR TITLE
[Hardening T2] Skip sleep after final reconnect attempt

### DIFF
--- a/app/integrations/kis_ws.py
+++ b/app/integrations/kis_ws.py
@@ -168,6 +168,9 @@ class KisWsClient:
                 if not self.running:
                     return False
 
+                if attempt == max_retries - 1:
+                    break
+
                 backoff = min(backoff_base_sec * (2**attempt), backoff_cap_sec)
                 sleep_fn(backoff)
 

--- a/tests/test_kis_ws_reconnect.py
+++ b/tests/test_kis_ws_reconnect.py
@@ -23,7 +23,7 @@ class TestKisWsReconnect(unittest.TestCase):
 
         self.assertFalse(result)
         self.assertEqual(len(attempts), 3)
-        self.assertEqual(sleeps, [1.0, 2.0, 4.0])
+        self.assertEqual(sleeps, [1.0, 2.0])
 
     def test_stop_signal_exits_reconnect_loop_immediately(self):
         client = KisWsClient()
@@ -47,6 +47,25 @@ class TestKisWsReconnect(unittest.TestCase):
         self.assertFalse(result)
         self.assertEqual(calls["count"], 1)
         self.assertEqual(sleeps, [])
+
+    def test_no_sleep_after_final_failed_attempt(self):
+        client = KisWsClient()
+        sleeps = []
+
+        def connect_once():
+            raise RuntimeError("disconnect")
+
+        result = client.run_with_reconnect(
+            connect_once=connect_once,
+            sleep_fn=lambda sec: sleeps.append(sec),
+            max_retries=3,
+            backoff_base_sec=1.0,
+            backoff_cap_sec=10.0,
+        )
+
+        self.assertFalse(result)
+        # retry between attempts only: 1->2, 2->3
+        self.assertEqual(sleeps, [1.0, 2.0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- avoid unnecessary backoff sleep after final failed reconnect attempt
- add explicit test coverage for final-attempt no-sleep behavior

## Verification
- python3 -m unittest tests/test_kis_ws_reconnect.py -v