### PR TITLE
[Hardening T4] Docs for typed cooldown and reconnect final-attempt policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ curl -s http://127.0.0.1:8890/v1/metrics/quote | jq
 - startup 시 WS client start, shutdown 시 stop 수행
 - `rest_fallbacks`, `ws_connected`, `last_ws_message_ts`를 운영 지표로 확인
 - `ws_heartbeat_fresh`, `ws_reconnect_count`, `ws_last_error`로 reconnect 상태를 함께 점검
-- REST 429 발생 시 `REST_RATE_LIMIT_COOLDOWN`(HTTP 503) 응답 정책 확인
+- REST 429 발생 시 `RestRateLimitCooldownError` → `REST_RATE_LIMIT_COOLDOWN`(HTTP 503) 응답 정책 확인
 
 ### 장중/장외 동작 기대치
 - 장중(09:00~15:30 KST): WS fresh면 `kis-ws`, stale/미수신이면 `kis-rest`
@@ -44,6 +44,7 @@ curl -s http://127.0.0.1:8890/v1/metrics/quote | jq
 
 ### 장애 대응 핵심
 - WS 끊김(reconnect): metrics 확인 → 프로세스 재기동/재연결 → `ws_connected`, `ws_heartbeat_fresh`, `ws_reconnect_count` 회복 확인
+- reconnect backoff는 final attempt 실패 후 추가 sleep 없이 종료되도록 동작
 - REST rate limit(429): 조회 빈도 축소, 백오프/재시도, `REST_RATE_LIMIT_COOLDOWN` 처리 확인
 - 인증(token): 토큰 발급/갱신 실패 시 APP_KEY/APP_SECRET 및 환경(mock/live) 재확인
 

--- a/docs/ops/kis-quote-runbook.md
+++ b/docs/ops/kis-quote-runbook.md
@@ -70,11 +70,12 @@ curl -s "http://127.0.0.1:8890/v1/metrics/quote" | jq
 2. 프로세스 재기동(WS 재연결 트리거)
 3. 재기동 후 `ws_connected`, `ws_messages` 증가 확인
 4. 복구 전까지 REST fallback으로 서비스 지속 (기능상 정상)
+5. reconnect는 final attempt 실패 시 추가 대기(sleep) 없이 종료됨을 전제로 알람/재기동 정책 구성
 
 ### B. REST rate limit / 실패
 증상:
 - 장외 또는 fallback 시 quote 조회 실패/지연
-- 429 이후 API가 `REST_RATE_LIMIT_COOLDOWN`(HTTP 503) 반환
+- 429 이후 내부 `RestRateLimitCooldownError`가 API에서 `REST_RATE_LIMIT_COOLDOWN`(HTTP 503)으로 매핑되어 반환
 
 대응:
 1. 호출 빈도 축소(필요 심볼만 조회)


### PR DESCRIPTION
## Summary
- document RestRateLimitCooldownError -> HTTP 503 mapping
- document reconnect final-attempt behavior (no extra sleep)
- align runbook operator guidance with hardening changes

## Verification
- rg -n "RestRateLimitCooldownError|final attempt|reconnect" README.md docs/ops/kis-quote-runbook.md