### PR TITLE
feat(ws): add KIS approval key issuance client

### DIFF
--- a/app/integrations/kis_rest.py
+++ b/app/integrations/kis_rest.py
@@ -57,6 +57,26 @@ class KisRestClient:
         self._token_expires_at = issued_at + refresh_ttl
         return token
 
+
+    def issue_approval_key(self) -> str:
+        response = self.session.post(
+            f"{self.base_url}/oauth2/Approval",
+            headers={"content-type": "application/json; charset=utf-8"},
+            json={
+                "grant_type": "client_credentials",
+                "appkey": self.app_key,
+                "secretkey": self.app_secret,
+            },
+            timeout=5,
+        )
+        response.raise_for_status()
+        payload = response.json()
+
+        approval_key = payload.get("approval_key")
+        if not approval_key:
+            raise ValueError("missing approval_key in response")
+        return str(approval_key)
+
     def get_access_token(self) -> str:
         if self._access_token and time.time() < self._token_expires_at:
             return self._access_token

--- a/app/integrations/kis_ws.py
+++ b/app/integrations/kis_ws.py
@@ -90,6 +90,7 @@ class KisWsClient:
         on_message: Optional[Callable[[Dict[str, Any]], None]] = None,
         *,
         approval_key: str = "",
+        approval_key_client: Optional[Any] = None,
         tr_id: str = "H0STCNT0",
         custtype: str = "P",
         tr_type: str = "1",
@@ -98,6 +99,7 @@ class KisWsClient:
         self._on_message = on_message
         self.running = False
         self.approval_key = approval_key
+        self._approval_key_client = approval_key_client
         self.tr_id = tr_id
         self.custtype = custtype
         self.tr_type = tr_type
@@ -113,6 +115,16 @@ class KisWsClient:
 
     def set_on_message(self, callback: Callable[[Dict[str, Any]], None]) -> None:
         self._on_message = callback
+
+
+    def ensure_approval_key(self) -> str:
+        if self.approval_key:
+            return self.approval_key
+        if self._approval_key_client is None:
+            raise ValueError("approval key client is not configured")
+
+        self.approval_key = str(self._approval_key_client.issue_approval_key())
+        return self.approval_key
 
     def build_subscribe_message(self, symbol: str) -> Dict[str, Any]:
         return {

--- a/tests/test_kis_rest_client.py
+++ b/tests/test_kis_rest_client.py
@@ -162,5 +162,39 @@ class TestKisRestClient(unittest.TestCase):
         self.assertEqual(session.post.call_count, 1)
 
 
+    def test_issue_approval_key_uses_kis_contract(self):
+        session = MagicMock()
+
+        approval_response = MagicMock()
+        approval_response.json.return_value = {
+            "approval_key": "approval-123",
+        }
+        approval_response.raise_for_status.return_value = None
+        session.post.return_value = approval_response
+
+        client = KisRestClient(
+            app_key="app-key",
+            app_secret="app-secret",
+            env="mock",
+            session=session,
+            base_url="https://example.test",
+        )
+
+        approval_key = client.issue_approval_key()
+
+        self.assertEqual(approval_key, "approval-123")
+        session.post.assert_called_once_with(
+            "https://example.test/oauth2/Approval",
+            headers={"content-type": "application/json; charset=utf-8"},
+            json={
+                "grant_type": "client_credentials",
+                "appkey": "app-key",
+                "secretkey": "app-secret",
+            },
+            timeout=5,
+        )
+
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Added `KisRestClient.issue_approval_key()` for KIS websocket approval-key issuance via `/oauth2/Approval`.
- Added response contract validation (`approval_key` required).
- Added minimal WS wiring in `KisWsClient` for approval-key client usage:
  - optional `approval_key_client` dependency
  - `ensure_approval_key()` helper
- Added/updated REST client test for approval endpoint contract.

## Verification
### RED (before implementation)
Command:
```bash
python3 -m unittest tests/test_kis_rest_client.py -v
```
Result:
```text
ERROR: test_issue_approval_key_uses_kis_contract
AttributeError: 'KisRestClient' object has no attribute 'issue_approval_key'
FAILED (errors=1)
```

### GREEN (after implementation)
Command:
```bash
python3 -m unittest tests/test_kis_rest_client.py -v
```
Result:
```text
Ran 5 tests in 0.008s
OK
```
