### PR TITLE
[WS Task5] docs-only checklist split from mixed PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ curl -s http://127.0.0.1:8890/v1/metrics/quote | jq
 - `ws_heartbeat_fresh`, `ws_reconnect_count`, `ws_last_error`로 reconnect 상태를 함께 점검
 - REST 429 발생 시 `RestRateLimitCooldownError` → `REST_RATE_LIMIT_COOLDOWN`(HTTP 503) 응답 정책 확인
 
+### Live WS 연결 검증 체크리스트
+- [ ] **Approval Key 발급 확인**: 기동 직후 로그에서 approval key 발급 성공 여부 확인(실패 시 APP_KEY/APP_SECRET/KIS_ENV 우선 점검)
+- [ ] **WebSocket 연결 + subscribe ACK 확인**: `ws_connected=true` 확인 후, subscribe 응답 ACK(성공 코드)와 초기 체결/호가 수신 로그 확인
+- [ ] **WS 지표 확인**: `/v1/metrics/quote`에서 `ws_messages` 증가, `last_ws_message_ts` 갱신, `ws_heartbeat_fresh=true`, `ws_last_error` 공백/안정 상태 확인
+
 ### 장중/장외 동작 기대치
 - 장중(09:00~15:30 KST): WS fresh면 `kis-ws`, stale/미수신이면 `kis-rest`
 - 장외: `kis-rest`

--- a/docs/ops/kis-quote-runbook.md
+++ b/docs/ops/kis-quote-runbook.md
@@ -40,6 +40,18 @@ curl -s http://127.0.0.1:8890/v1/metrics/quote | jq
 - 앱 shutdown 시 WS client stop이 호출되도록 구현됨
 - 배포/재기동 시 **graceful stop 후 재시작** 권장
 
+### 2-1) Live WS 연결 검증 체크리스트
+1. **Approval Key 발급 확인**
+   - 기동 직후 로그에서 approval key 발급 성공 이벤트 확인
+   - 실패 시 `KIS_APP_KEY`, `KIS_APP_SECRET`, `KIS_ENV(live)` 값 우선 재검증
+2. **WebSocket 연결 + subscribe ACK 확인**
+   - `/v1/metrics/quote`에서 `ws_connected=true` 확인
+   - subscribe ACK(성공 코드) 및 초기 실시간 메시지 수신 로그 확인
+3. **WS 지표 정상성 확인**
+   - `ws_messages`가 시간 경과에 따라 증가
+   - `last_ws_message_ts`가 최근 시각으로 지속 갱신
+   - `ws_heartbeat_fresh=true`, `ws_last_error` 비정상 값 없음
+
 ## 3) 장중/장외 기대 동작 (WS vs REST)
 
 - 장중(09:00~15:30 KST):


### PR DESCRIPTION
## Why\nPR #33 mixed docs with already-merged code commits, failing docs-only QA scope.\nThis PR contains docs-only changes for Task5.\n\n## Changes\n- README.md: WS live-connection checklist (Approval, websocket subscribe ACK, metrics points)\n- docs/ops/kis-quote-runbook.md: same operator checklist details\n\n## Verification\n- rg -n "Approval|ws_connected|subscribe|websocket|mock" README.md docs/ops/kis-quote-runbook.md\n- python3 -m unittest tests/test_quote_e2e_mock_kis.py -v\n