### PR TITLE
feat(config): add ws symbols setting for runtime subscribe

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -10,15 +10,22 @@ class Settings(BaseModel):
     KIS_APP_SECRET: str
     KIS_ACCOUNT_NO: str
     KIS_ENV: Literal["mock", "live"]
+    KIS_WS_SYMBOLS: list[str]
 
     @classmethod
     def from_env(cls) -> "Settings":
+        raw_ws_symbols = os.getenv("KIS_WS_SYMBOLS", "005930")
+        ws_symbols = [s.strip() for s in raw_ws_symbols.split(",") if s.strip()]
+        if not ws_symbols:
+            ws_symbols = ["005930"]
+
         return cls.model_validate(
             {
                 "KIS_APP_KEY": os.getenv("KIS_APP_KEY"),
                 "KIS_APP_SECRET": os.getenv("KIS_APP_SECRET"),
                 "KIS_ACCOUNT_NO": os.getenv("KIS_ACCOUNT_NO"),
                 "KIS_ENV": os.getenv("KIS_ENV"),
+                "KIS_WS_SYMBOLS": ws_symbols,
             }
         )
 

--- a/app/main.py
+++ b/app/main.py
@@ -43,7 +43,9 @@ async def lifespan(app: FastAPI):
 
     ws_worker = threading.Thread(
         target=lambda: app.state.ws_client.run_with_reconnect(
-            connect_once=lambda: app.state.ws_client.connect_and_subscribe(symbols=['005930'])
+            connect_once=lambda: app.state.ws_client.connect_and_subscribe(
+                symbols=app.state.get_settings().KIS_WS_SYMBOLS
+            )
         ),
         daemon=True,
         name='kis-ws-worker',

--- a/tests/test_kis_config.py
+++ b/tests/test_kis_config.py
@@ -28,6 +28,31 @@ class TestKisSettings(unittest.TestCase):
         self.assertEqual(settings.KIS_ACCOUNT_NO, "12345678-01")
         self.assertEqual(settings.KIS_ENV, "mock")
 
+    def test_ws_symbols_default_is_single_samsung(self):
+        env = {
+            "KIS_APP_KEY": "app-key",
+            "KIS_APP_SECRET": "app-secret",
+            "KIS_ACCOUNT_NO": "12345678-01",
+            "KIS_ENV": "mock",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            settings = Settings.from_env()
+
+        self.assertEqual(settings.KIS_WS_SYMBOLS, ["005930"])
+
+    def test_ws_symbols_parses_comma_separated_values(self):
+        env = {
+            "KIS_APP_KEY": "app-key",
+            "KIS_APP_SECRET": "app-secret",
+            "KIS_ACCOUNT_NO": "12345678-01",
+            "KIS_ENV": "mock",
+            "KIS_WS_SYMBOLS": " 005930, 000660 , 035420 ",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            settings = Settings.from_env()
+
+        self.assertEqual(settings.KIS_WS_SYMBOLS, ["005930", "000660", "035420"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add `KIS_WS_SYMBOLS` setting to `Settings` with default fallback `["005930"]`
- parse comma-separated env values into trimmed symbol list
- wire lifespan WS startup subscribe symbols from `settings.KIS_WS_SYMBOLS` instead of hardcoded single symbol
- add config tests for default and comma-separated parse contract

## Verification Logs
### RED (before implementation)
```bash
$ python3 -m unittest tests/test_kis_config.py -v
...
test_ws_symbols_default_is_single_samsung ... ERROR
test_ws_symbols_parses_comma_separated_values ... ERROR
AttributeError: 'Settings' object has no attribute 'KIS_WS_SYMBOLS'
FAILED (errors=2)
```

### GREEN (after implementation)
```bash
$ python3 -m unittest tests/test_kis_config.py -v
test_missing_required_env_fails_validation ... ok
test_valid_env_loads_settings ... ok
test_ws_symbols_default_is_single_samsung ... ok
test_ws_symbols_parses_comma_separated_values ... ok

Ran 4 tests in 0.002s
OK
```

## Scope
- narrow scoped changes only: `app/config/settings.py`, `app/main.py`, `tests/test_kis_config.py`
- backward compatibility kept by defaulting WS symbols to existing runtime behavior (`005930`)
