### PR TITLE
[WS Runtime T4] docs-only split for runtime activation checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ export KIS_APP_KEY="..."
 export KIS_APP_SECRET="..."
 export KIS_ACCOUNT_NO="12345678-01"
 export KIS_ENV="mock"  # mock | live
+export KIS_WS_SYMBOLS="005930,000660"  # 런타임 WS subscribe 대상(콤마 구분)
 ```
 
 ### Startup/Lifecycle 점검
@@ -33,7 +34,7 @@ export KIS_ENV="mock"  # mock | live
 curl -s http://127.0.0.1:8890/v1/session/status | jq
 curl -s http://127.0.0.1:8890/v1/metrics/quote | jq
 ```
-- startup 시 WS client start, shutdown 시 stop 수행
+- startup(lifespan)에서 `KIS_WS_SYMBOLS` 기준 WS subscribe 시작, shutdown(lifespan)에서 stop 수행
 - `rest_fallbacks`, `ws_connected`, `last_ws_message_ts`를 운영 지표로 확인
 - `ws_heartbeat_fresh`, `ws_reconnect_count`, `ws_last_error`로 reconnect 상태를 함께 점검
 - REST 429 발생 시 `RestRateLimitCooldownError` → `REST_RATE_LIMIT_COOLDOWN`(HTTP 503) 응답 정책 확인
@@ -42,6 +43,7 @@ curl -s http://127.0.0.1:8890/v1/metrics/quote | jq
 - [ ] **Approval Key 발급 확인**: 기동 직후 로그에서 approval key 발급 성공 여부 확인(실패 시 APP_KEY/APP_SECRET/KIS_ENV 우선 점검)
 - [ ] **WebSocket 연결 + subscribe ACK 확인**: `ws_connected=true` 확인 후, subscribe 응답 ACK(성공 코드)와 초기 체결/호가 수신 로그 확인
 - [ ] **WS 지표 확인**: `/v1/metrics/quote`에서 `ws_messages` 증가, `last_ws_message_ts` 갱신, `ws_heartbeat_fresh=true`, `ws_last_error` 공백/안정 상태 확인
+- [ ] **런타임 활성화 확인**: `/v1/quotes/{symbol}` 응답에서 장중 기준 `source="kis-ws"` 확인(예: `005930`), 미활성 시 `KIS_WS_SYMBOLS`/lifespan 기동 로그 재확인
 
 ### 장중/장외 동작 기대치
 - 장중(09:00~15:30 KST): WS fresh면 `kis-ws`, stale/미수신이면 `kis-rest`

--- a/docs/ops/kis-quote-runbook.md
+++ b/docs/ops/kis-quote-runbook.md
@@ -11,6 +11,7 @@ export KIS_APP_KEY="..."
 export KIS_APP_SECRET="..."
 export KIS_ACCOUNT_NO="12345678-01"
 export KIS_ENV="mock"   # mock | live
+export KIS_WS_SYMBOLS="005930,000660"  # 런타임 WS subscribe 대상(콤마 구분)
 ```
 
 앱 실행:
@@ -33,6 +34,7 @@ curl -s http://127.0.0.1:8890/v1/metrics/quote | jq
 
 정상 기준:
 - `/v1/session/status` 응답 OK
+- startup/lifespan 로그에서 WS runtime activation(시작) 확인
 - `/v1/metrics/quote`에 최소 키 존재: `cached_symbols`, `ws_messages`, `rest_fallbacks`, `ws_connected`, `last_ws_message_ts`
 - 추가 키 확인: `ws_heartbeat_fresh`, `ws_reconnect_count`, `ws_last_error`
 
@@ -46,7 +48,7 @@ curl -s http://127.0.0.1:8890/v1/metrics/quote | jq
    - 실패 시 `KIS_APP_KEY`, `KIS_APP_SECRET`, `KIS_ENV(live)` 값 우선 재검증
 2. **WebSocket 연결 + subscribe ACK 확인**
    - `/v1/metrics/quote`에서 `ws_connected=true` 확인
-   - subscribe ACK(성공 코드) 및 초기 실시간 메시지 수신 로그 확인
+   - `KIS_WS_SYMBOLS`에 지정한 심볼 기준 subscribe ACK(성공 코드) 및 초기 실시간 메시지 수신 로그 확인
 3. **WS 지표 정상성 확인**
    - `ws_messages`가 시간 경과에 따라 증가
    - `last_ws_message_ts`가 최근 시각으로 지속 갱신
@@ -69,6 +71,7 @@ curl -s "http://127.0.0.1:8890/v1/metrics/quote" | jq
 판단 포인트:
 - `rest_fallbacks` 증가: WS stale/미수신 또는 장외 REST 사용
 - `ws_connected=false` + 장중: WS 경로 점검 필요
+- 장중 `/v1/quotes/{symbol}` 결과가 `source="kis-ws"`면 runtime activation 정상
 
 ## 4) 장애 대응
 


### PR DESCRIPTION
## Why
PR #38 failed docs-only QA because stacked code/test commits were included.
This split PR contains docs-only Task4 changes.

## Changes
- README.md
- docs/ops/kis-quote-runbook.md

## Verification
- rg -n "ws_connected|ws_messages|source.*kis-ws|KIS_WS_SYMBOLS|lifespan" README.md docs/ops/kis-quote-runbook.md
- python3 -m unittest tests/test_quote_e2e_mock_kis.py -v
