### PR TITLE
[Env] add mock env template and mock runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ export KIS_ENV="mock"  # mock | live
 export KIS_WS_SYMBOLS="005930,000660"  # 런타임 WS subscribe 대상(콤마 구분)
 ```
 
+### Mock env 파일로 실행 (권장)
+```bash
+cp env/mock.env.example env/mock.env
+# env/mock.env 값 채운 뒤
+./scripts/run_mock_server.sh
+```
+
+> `env/mock.env`가 없으면 `KIS_MOCK_APP_KEY`, `KIS_MOCK_APP_SECRET`, `KIS_MOCK_CANO`, `KIS_MOCK_ACNT_PRDT_CD_KR` 환경변수를 fallback으로 사용합니다.
+
 ### Startup/Lifecycle 점검
 ```bash
 curl -s http://127.0.0.1:8890/v1/session/status | jq

--- a/env/mock.env.example
+++ b/env/mock.env.example
@@ -1,0 +1,6 @@
+# Copy to env/mock.env and fill values for mock runtime
+KIS_APP_KEY=your_mock_app_key
+KIS_APP_SECRET=your_mock_app_secret
+KIS_ACCOUNT_NO=12345678-01
+KIS_ENV=mock
+KIS_WS_SYMBOLS=005930,000660

--- a/scripts/run_mock_server.sh
+++ b/scripts/run_mock_server.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="$ROOT_DIR/env/mock.env"
+
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "$ENV_FILE"
+  set +a
+else
+  # Fallback to OpenClaw env vars if present
+  export KIS_APP_KEY="${KIS_APP_KEY:-${KIS_MOCK_APP_KEY:-}}"
+  export KIS_APP_SECRET="${KIS_APP_SECRET:-${KIS_MOCK_APP_SECRET:-}}"
+  if [[ -n "${KIS_MOCK_CANO:-}" ]]; then
+    export KIS_ACCOUNT_NO="${KIS_ACCOUNT_NO:-${KIS_MOCK_CANO}-${KIS_MOCK_ACNT_PRDT_CD_KR:-01}}"
+  fi
+  export KIS_ENV="${KIS_ENV:-mock}"
+  export KIS_WS_SYMBOLS="${KIS_WS_SYMBOLS:-005930,000660}"
+fi
+
+: "${KIS_APP_KEY:?KIS_APP_KEY is required}"
+: "${KIS_APP_SECRET:?KIS_APP_SECRET is required}"
+: "${KIS_ACCOUNT_NO:?KIS_ACCOUNT_NO is required}"
+
+exec uvicorn app.main:app --host 127.0.0.1 --port 8890


### PR DESCRIPTION
## Scope\n- env/mock.env.example\n- scripts/run_mock_server.sh\n- README.md\n\n## Why\nUse mock env file/config-driven startup instead of manual export each run.\n\n## Verification\n- timeout 15s ./scripts/run_mock_server.sh\n- curl -sS http://127.0.0.1:8890/v1/session/status\n- curl -sS http://127.0.0.1:8890/v1/metrics/quote\n\n## Result\n- server starts in mock mode\n- session/metrics endpoints return 200\n