### PR TITLE
fix(ws): recover ws connected-state sync and add runtime debug evidence

### DIFF
--- a/docs/evidence/2026-02-28-ws-debug-compare-mock-live.md
+++ b/docs/evidence/2026-02-28-ws-debug-compare-mock-live.md
@@ -1,0 +1,6 @@
+# WS Debug Compare: mock vs live (same credentials)
+
+| mode | ws_connected(t1→t2) | ws_messages(t1→t2) | ws_reconnect(t1→t2) | quote source | ws_last_error |
+|---|---|---|---|---|---|
+| mock | True → True | 0 → 0 | 0 → 0 | kis-rest | None |
+| live | True → True | 0 → 0 | 0 → 0 | kis-rest | None |

--- a/docs/evidence/2026-02-28-ws-real-final-report.md
+++ b/docs/evidence/2026-02-28-ws-real-final-report.md
@@ -1,49 +1,53 @@
 # WS Real Exchange Validation Final Report (2026-02-28)
 
 ## 검증 범위/환경
-- 범위: `docs/plans/2026-02-28-kis-ws-real-exchange-validation.md` Task1~Task4 실행 증거 기반 종합 판정
+- 범위: `docs/plans/2026-02-28-kis-ws-real-exchange-validation.md` + `docs/plans/2026-02-28-ws-runtime-debugging-plan.md` 실행 증거 기반 종합 판정
 - 환경: 로컬 런타임 `127.0.0.1:8890`, `KIS_ENV=live`, `KIS_MOCK=false`
-- 제약: 실제 live credential(`KIS_APP_KEY`, `KIS_APP_SECRET`, `KIS_ACCOUNT_NO`) 미주입 상태
+- 제약: 장종료 시간대(16:00+) 검증으로 체결성 quote payload 유입량 제한 가능
 
 ## 태스크별 요약
 1. **Task1 (preflight safety)**: PASS
    - read-only/주문 금지/마스킹 규칙 문서화 완료
-2. **Task2 (connect + ACK)**: PARTIAL
-   - 앱 기동/metrics 조회는 가능
-   - WS 실연결/ACK은 credential 부재로 미달
-3. **Task3 (source="kis-ws")**: FAIL
-   - 5회 샘플 모두 `source="kis-rest"`
+2. **Task2 (connect + ACK/control)**: PASS
+   - WS worker 시작/연결/subscribe/control 수신 로그 확인
+   - `ws_connected=true` 상태 동기화 복구 완료
+3. **Task3 (source="kis-ws")**: PARTIAL
+   - mock/live 모두 연결은 성공했으나 quote payload 미수신으로 `source="kis-rest"` 유지
 4. **Task4 (reconnect baseline)**: PARTIAL
-   - `ws_reconnect_count` 증가는 관측
-   - `ws_connected=true` 회복은 미달
+   - 연결 상태는 유지되나 quote 메시지 누적으로 이어지지 않음
 
 ## 핵심 관측치
-- `/v1/metrics/quote`
-  - `ws_connected=false`
+- `/v1/metrics/quote` (mock/live A/B 동일)
+  - `ws_connected=true`
   - `ws_messages=0`
-  - `ws_last_error`:
-    - `KIS_APP_KEY`/`KIS_APP_SECRET`/`KIS_ACCOUNT_NO` validation error
+  - `ws_last_error=None`
+- 서버 로그
+  - `[WS][ws_connect_result] status=open`
+  - `[WS][ws_subscribe] symbol=005930`
+  - `[WS][ws_message_skip] reason=missing symbol in payload` (control/ACK로 해석)
 - `/v1/quotes/005930`
   - `source="kis-rest"` 지속
 
 ## 리스크
-- 현재 상태에서 실거래소 WS 경로가 비활성이라 장중 WS-first 운영 검증 실패.
-- 실키 주입 전까지 실시간 경로 품질(SLA/TTR) 실측 불가.
+- 연결은 살아있지만 quote payload가 없어 WS-first 소스 전환(`kis-ws`)을 입증하지 못함.
+- 장종료 시간대 검증/실키 권한(TR/상품 권한) 이슈가 겹치면 원인 분리가 어려움.
 
 ## 판정 (Go/No-Go)
-- **No-Go** (실거래소 WS 운영 검증 완료 기준 미충족)
+- **No-Go 유지** (연결 복구는 확인했으나 `ws_messages>0` 및 `source="kis-ws"` 미충족)
 
 ## Go 전환 조건 (즉시 실행 체크리스트)
-1. live credential 주입 (`KIS_APP_KEY`, `KIS_APP_SECRET`, `KIS_ACCOUNT_NO`)
+1. 장중(09:00~15:30) 동일 시나리오 재실행
 2. 런타임 재기동 후 `/v1/metrics/quote`에서
    - `ws_connected=true`
    - `ws_messages>0`
    - `ws_heartbeat_fresh=true`
 3. `/v1/quotes/{symbol}` 장중 3회 이상 `source="kis-ws"` 확인
-4. reconnect 이벤트 후 회복 시간(TTR) 기록
+4. 필요 시 TR_ID/구독 채널 권한 점검(계좌/앱 권한)
+5. reconnect 이벤트 후 회복 시간(TTR) 기록
 
 ## 관련 증거 문서
 - `docs/evidence/2026-02-28-ws-real-preflight.md`
 - `docs/evidence/2026-02-28-ws-real-connect.md`
 - `docs/evidence/2026-02-28-ws-real-quote-source.md`
 - `docs/evidence/2026-02-28-ws-real-reconnect.md`
+- `docs/evidence/2026-02-28-ws-debug-compare-mock-live.md`

--- a/docs/plans/2026-02-28-ws-runtime-debugging-plan.md
+++ b/docs/plans/2026-02-28-ws-runtime-debugging-plan.md
@@ -1,0 +1,178 @@
+# WS Runtime Debugging Implementation Plan
+
+> REQUIRED EXECUTION SKILL: `executing-plans`
+
+**Goal:** WS 실시간 경로가 mock/live 모두에서 `ws_connected=false`, `ws_messages=0`, `source="kis-rest"`로 고정되는 원인을 재현 가능한 증거로 특정하고, 최소 수정으로 `source="kis-ws"` 경로를 복구한다.
+**Architecture:** FastAPI `lifespan`에서 WS worker를 기동하고, WS 콜백이 quote cache/metrics를 갱신한 뒤 quote API가 장중 fresh 데이터면 `kis-ws`를 반환한다. 현재 실패는 (1) worker 미기동, (2) subscribe 미실행, (3) 메시지 파싱/반영 누락 중 하나일 가능성이 높다. 단계별 경계(기동→연결→구독→수신→캐시반영→응답선택)를 분리해 좁혀간다.
+**Tech Stack:** Python 3.10, FastAPI, unittest, uvicorn, curl, rg, 로그 파일(/tmp)
+
+---
+
+### Task 1: WS 경계별 계측 포인트 확인(코드 읽기 + 실패 가설 확정)
+
+**Files**
+- Modify: 없음 (읽기/분석)
+- Inspect: `app/main.py`, `app/services/*ws*`, `app/services/quote_gateway.py`, `app/api/routes.py`
+
+**Step 1 — Failing check**
+```bash
+rg -n "run_with_reconnect|connect_once|subscribe|on_message|ws_connected|ws_messages|source" app
+```
+
+**Step 2 — Verify fail**
+Run: 위 명령
+Expect: 경계별 함수/호출순서가 산재되어 있어 단일 원인 파악 불가 상태 확인
+
+**Step 3 — Minimal implementation (분석 산출물)
+**
+- 아래 가설 3개를 문서화:
+  1) lifespan에서 worker 스레드가 실제 루프 진입 전 종료됨
+  2) subscribe ACK/메시지 콜백이 metrics에 반영되지 않음
+  3) quote 선택 로직이 WS fresh를 제외하고 REST로 고정됨
+
+**Step 4 — Verify pass**
+Run:
+```bash
+python3 - <<'PY'
+print('HYPOTHESIS_READY')
+PY
+```
+Expect: `HYPOTHESIS_READY`
+
+**Step 5 — Checkpoint**
+- 아직 커밋 없음 (Task2에서 증거 문서와 함께 커밋)
+
+---
+
+### Task 2: 런타임 관측 강화(로그 증거 추가, 동작 변경 없음)
+
+**Files**
+- Modify: `app/main.py`, `app/services/...(ws worker/client 관련 파일)`
+- Test: `tests/test_quote_e2e_mock_kis.py` (기존 통과 유지)
+
+**Step 1 — Failing test**
+```bash
+export KIS_ENV=mock
+export KIS_ACCOUNT_NO="${KIS_CANO}-${KIS_ACNT_PRDT_CD_KR:-01}"
+timeout 20s uvicorn app.main:app --host 127.0.0.1 --port 8890
+```
+
+**Step 2 — Verify fail**
+Run (별도 터미널):
+```bash
+curl -sS http://127.0.0.1:8890/v1/metrics/quote
+```
+Expect: `ws_connected=false`, `ws_messages=0` 상태에서 원인 로그가 부족
+
+**Step 3 — Minimal implementation**
+- 구조 로그 4개 추가 (민감정보 마스킹):
+  - worker start/stop
+  - WS connect attempt/result
+  - subscribe request/ack result
+  - first message ingest
+
+**Step 4 — Verify pass**
+Run:
+```bash
+(timeout 20s uvicorn app.main:app --host 127.0.0.1 --port 8890 > /tmp/ws_debug.log 2>&1 &) ; sleep 5; rg -n "ws_worker_start|ws_connect|ws_subscribe|ws_first_message" /tmp/ws_debug.log
+```
+Expect: 최소 2개 이상 단계 로그 확인
+
+**Step 5 — Checkpoint**
+Run: `git add app/main.py app/services/* && git commit -m "chore(ws): add runtime stage logs for ws debugging"`
+
+---
+
+### Task 3: 원인 분기 실험 (mock/live 동일키 비교 자동화)
+
+**Files**
+- Create: `scripts/ws_compare_env_modes.sh`
+- Create: `docs/evidence/2026-02-28-ws-debug-compare-mock-live.md`
+
+**Step 1 — Failing check**
+```bash
+bash scripts/ws_compare_env_modes.sh
+```
+
+**Step 2 — Verify fail**
+Expect: 현재와 같이 mock/live 모두 `ws_connected=false`, `ws_messages=0` 재현
+
+**Step 3 — Minimal implementation**
+- 비교 스크립트에서 동일 키/계정으로 `KIS_ENV`만 변경해 두 번 기동
+- 각 모드에서 metrics 2회 + quote 1회 캡처 후 표 형태로 evidence 저장
+
+**Step 4 — Verify pass**
+Run:
+```bash
+rg -n "mock|live|ws_connected|ws_messages|source" docs/evidence/2026-02-28-ws-debug-compare-mock-live.md
+```
+Expect: 모드별 비교 라인 생성
+
+**Step 5 — Checkpoint**
+Run: `git add scripts/ws_compare_env_modes.sh docs/evidence/2026-02-28-ws-debug-compare-mock-live.md && git commit -m "docs(debug): add mock-live ws compare evidence"`
+
+---
+
+### Task 4: 원인점 최소 수정 (가설 1개만 고치기)
+
+**Files**
+- Modify: Task2/3 결과로 특정된 최소 파일
+- Test: `tests/test_quote_e2e_mock_kis.py`, `tests/test_kis_ws_live_client.py`
+
+**Step 1 — Failing test**
+```bash
+python3 -m unittest tests/test_quote_e2e_mock_kis.py -v
+```
+
+**Step 2 — Verify fail**
+Expect: WS 경로 관련 테스트 또는 수동 재현에서 실패 유지
+
+**Step 3 — Minimal implementation**
+- 원인 1개만 수정 (예: subscribe 호출 누락/콜백 누락/상태 동기화 누락)
+
+**Step 4 — Verify pass**
+Run:
+```bash
+python3 -m unittest tests/test_quote_e2e_mock_kis.py -v
+python3 -m unittest tests/test_kis_ws_live_client.py -v
+```
+Expect: 관련 테스트 PASS
+
+**Step 5 — Checkpoint**
+Run: `git add ... && git commit -m "fix(ws): restore ws ingest path for runtime worker"`
+
+---
+
+### Task 5: 최종 회귀 + 운영 판정 업데이트
+
+**Files**
+- Modify: `docs/evidence/2026-02-28-ws-real-final-report.md`
+
+**Step 1 — Failing check**
+```bash
+curl -sS http://127.0.0.1:8890/v1/metrics/quote
+```
+
+**Step 2 — Verify fail**
+Expect: 수정 전 기준값 기록
+
+**Step 3 — Minimal implementation**
+- 최종 관측값 반영해 Go/No-Go 재판정
+
+**Step 4 — Verify pass**
+Run:
+```bash
+python3 -m unittest discover -s tests -v
+```
+Expect: 전체 PASS
+
+**Step 5 — Checkpoint**
+Run: `git add docs/evidence/2026-02-28-ws-real-final-report.md && git commit -m "docs(evidence): update ws final decision after runtime debugging"`
+
+---
+
+## Handoff
+1) Current session execution: 지금 이 세션에서 Task1부터 연속 수행
+2) Subagent execution: coder(구현) + qa(검증)로 Task별 PR 사이클 유지
+
+권장: 2) (현재 운영 원칙과 동일한 PR/QA/merge 파이프라인 유지)

--- a/scripts/ws_compare_env_modes.sh
+++ b/scripts/ws_compare_env_modes.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+ACCOUNT_NO="${KIS_ACCOUNT_NO:-${KIS_CANO:-}-${KIS_ACNT_PRDT_CD:-${KIS_ACNT_PRDT_CD_KR:-01}}}"
+if [[ -z "${KIS_APP_KEY:-}" || -z "${KIS_APP_SECRET:-}" || -z "$ACCOUNT_NO" ]]; then
+  echo "[ERR] KIS_APP_KEY/KIS_APP_SECRET/KIS_ACCOUNT_NO(or KIS_CANO+KIS_ACNT_PRDT_CD) required" >&2
+  exit 1
+fi
+
+export KIS_ACCOUNT_NO="$ACCOUNT_NO"
+export KIS_WS_SYMBOLS="${KIS_WS_SYMBOLS:-005930}"
+
+run_case() {
+  local mode="$1"
+  export KIS_ENV="$mode"
+
+  local log="/tmp/ws_cmp_${mode}.log"
+  local m1="/tmp/ws_cmp_${mode}_m1.json"
+  local m2="/tmp/ws_cmp_${mode}_m2.json"
+  local q1="/tmp/ws_cmp_${mode}_q1.json"
+
+  timeout 22s uvicorn app.main:app --host 127.0.0.1 --port 8890 >"$log" 2>&1 &
+  local pid=$!
+
+  local ok=0
+  for _ in 1 2 3 4 5 6 7; do
+    if curl -fsS http://127.0.0.1:8890/v1/metrics/quote >"$m1" 2>/dev/null; then
+      ok=1
+      break
+    fi
+    sleep 1
+  done
+
+  if [[ "$ok" -eq 1 ]]; then
+    curl -sS http://127.0.0.1:8890/v1/quotes/005930 >"$q1"
+    sleep 8
+    curl -sS http://127.0.0.1:8890/v1/metrics/quote >"$m2"
+  else
+    echo "{}" >"$m1"
+    echo "{}" >"$m2"
+    echo "{}" >"$q1"
+  fi
+
+  wait "$pid" || true
+}
+
+run_case mock
+run_case live
+
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+def load(p):
+    return json.loads(Path(p).read_text())
+
+rows = []
+for mode in ("mock", "live"):
+    m1 = load(f"/tmp/ws_cmp_{mode}_m1.json")
+    m2 = load(f"/tmp/ws_cmp_{mode}_m2.json")
+    q1 = load(f"/tmp/ws_cmp_{mode}_q1.json")
+    rows.append({
+        "mode": mode,
+        "ws_connected_t1": m1.get("ws_connected"),
+        "ws_connected_t2": m2.get("ws_connected"),
+        "ws_messages_t1": m1.get("ws_messages"),
+        "ws_messages_t2": m2.get("ws_messages"),
+        "ws_reconnect_t1": m1.get("ws_reconnect_count"),
+        "ws_reconnect_t2": m2.get("ws_reconnect_count"),
+        "quote_source": q1.get("source"),
+        "ws_last_error": m2.get("ws_last_error"),
+    })
+
+out = Path("docs/evidence/2026-02-28-ws-debug-compare-mock-live.md")
+out.parent.mkdir(parents=True, exist_ok=True)
+lines = [
+    "# WS Debug Compare: mock vs live (same credentials)",
+    "",
+    "| mode | ws_connected(t1→t2) | ws_messages(t1→t2) | ws_reconnect(t1→t2) | quote source | ws_last_error |",
+    "|---|---|---|---|---|---|",
+]
+for r in rows:
+    lines.append(
+        f"| {r['mode']} | {r['ws_connected_t1']} → {r['ws_connected_t2']} | {r['ws_messages_t1']} → {r['ws_messages_t2']} | {r['ws_reconnect_t1']} → {r['ws_reconnect_t2']} | {r['quote_source']} | {r['ws_last_error']} |"
+    )
+out.write_text("\n".join(lines) + "\n")
+print(out)
+PY
+
+echo "[OK] docs/evidence/2026-02-28-ws-debug-compare-mock-live.md generated"


### PR DESCRIPTION
## Summary
- 연결 상태가 metrics에 반영되지 않던 경로를 복구 (`on_state_change -> quote_ingest_worker.sync_ws_state`)
- KIS WS 런타임 단계 로그(worker/connect/subscribe/first message) 추가
- control/ACK 메시지(`missing symbol`)는 ingest skip 처리하여 루프 안정화
- mock/live 동일 자격증명 비교 스크립트 추가 (`scripts/ws_compare_env_modes.sh`)
- 증거 문서 갱신

## Verification
- python3 -m unittest discover -s tests -v  (66 tests, OK)
- bash scripts/ws_compare_env_modes.sh
  - mock/live 모두 ws_connected=True, ws_messages=0, source=kis-rest

## Notes
- 장종료 시간대 검증으로 quote payload 유입이 제한되어 source=kis-ws는 미충족
- 최종 판정은 No-Go 유지
