### PR TITLE
feat(order): define buy/sell api contract and error codes

### DIFF
--- a/app/schemas/order.py
+++ b/app/schemas/order.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 
 class OrderRequest(BaseModel):
@@ -9,6 +9,16 @@ class OrderRequest(BaseModel):
     order_type: str = "LIMIT"
     price: float | None = None
     strategy_id: str | None = None
+
+    @field_validator("side")
+    @classmethod
+    def normalize_side(cls, value: str) -> str:
+        return value.upper()
+
+    @field_validator("order_type")
+    @classmethod
+    def normalize_order_type(cls, value: str) -> str:
+        return value.upper()
 
 
 class OrderAccepted(BaseModel):

--- a/docs/ops/order-api-contract.md
+++ b/docs/ops/order-api-contract.md
@@ -1,0 +1,43 @@
+# Order API Contract (Task 1)
+
+## Endpoint
+- `POST /v1/orders`
+
+## Request Body
+- `account_id` (string, required)
+- `symbol` (string, required)
+- `side` (string, required): `BUY` | `SELL` (case-insensitive input, normalized to uppercase)
+- `qty` (int, required): must be `>= 1`
+- `order_type` (string, optional, default `LIMIT`): `LIMIT` | `MARKET` (case-insensitive input, normalized to uppercase)
+- `price` (number, optional)
+  - `LIMIT`: `price` required
+  - `MARKET`: `price` must be omitted
+- `strategy_id` (string, optional)
+
+## Required Header
+- `Idempotency-Key` (required)
+
+## Success Response
+`200 OK`
+```json
+{
+  "order_id": "ord_...",
+  "status": "ACCEPTED",
+  "idempotency_key": "..."
+}
+```
+
+## Error Codes
+- `INVALID_QTY`
+- `INVALID_PRICE`
+- `NOTIONAL_LIMIT_EXCEEDED`
+- `OUT_OF_TRADING_WINDOW`
+- `IDEMPOTENCY_KEY_BODY_MISMATCH` (HTTP 409)
+- `INVALID_SIDE`
+- `INVALID_ORDER_TYPE`
+- `PRICE_REQUIRED_FOR_LIMIT`
+- `PRICE_NOT_ALLOWED_FOR_MARKET`
+
+## Error Mapping
+- `400`: contract/risk violations
+- `409`: idempotency body hash mismatch


### PR DESCRIPTION
## Summary
- Fixed buy/sell order API contract at Task 1 scope.
- Added explicit order contract validation and standardized error codes in `POST /v1/orders`.
- Added ops contract document for request/response/error mapping.

## Changes
- `app/schemas/order.py`
  - Added normalization validators for `side`, `order_type` (uppercase).
- `app/api/routes.py`
  - Added `_validate_order_contract` with fixed error codes:
    - `INVALID_SIDE`
    - `INVALID_ORDER_TYPE`
    - `PRICE_REQUIRED_FOR_LIMIT`
    - `PRICE_NOT_ALLOWED_FOR_MARKET`
  - Applied contract validation before risk check.
- `docs/ops/order-api-contract.md`
  - Added Task 1 API contract and error mapping documentation.
- `tests/test_mvp_iteration1.py`
  - Added contract tests for side/order_type/price rule enforcement.

## Verification
### 1) Fail-first evidence
Command:
```bash
python3 -m unittest tests/test_mvp_iteration1.py -v
```
Key output:
- `FAILED (failures=3)`
- `test_order_create_invalid_side_returns_error_code ... FAIL`
- `test_order_create_limit_order_requires_price ... FAIL`
- `test_order_create_market_order_forbids_price ... FAIL`

### 2) After minimal implementation
Command:
```bash
python3 -m unittest tests/test_mvp_iteration1.py -v
```
Key output:
- `Ran 26 tests`
- `OK`

## Risk
- Legacy behavior keeps allowing omitted `order_type` + omitted `price` path for compatibility (enforced LIMIT price rule when `order_type` is explicitly provided).
- Additional strictness may affect clients that were sending invalid `side` or `MARKET+price` payloads.
