### PR TITLE
feat(risk): split buy/sell risk policies

### DIFF
--- a/app/services/risk_policy.py
+++ b/app/services/risk_policy.py
@@ -1,0 +1,29 @@
+from app.schemas.risk import RiskCheckRequest
+
+_DEFAULT_PRICE = 70000
+_BUY_NOTIONAL_CAP = 10000000
+
+
+def get_available_sell_qty(account_id: str, symbol: str) -> int:
+    # TODO(task3+): replace with broker/account adapter lookup.
+    return 0
+
+
+def evaluate_side_policy(
+    req: RiskCheckRequest,
+    *,
+    get_available_sell_qty=get_available_sell_qty,
+) -> dict[str, bool | str | None]:
+    if req.side == 'BUY':
+        effective_price = req.price if req.price is not None else _DEFAULT_PRICE
+        if req.qty * effective_price > _BUY_NOTIONAL_CAP:
+            return {'ok': False, 'reason': 'NOTIONAL_LIMIT_EXCEEDED'}
+        return {'ok': True, 'reason': None}
+
+    if req.side == 'SELL':
+        available_qty = get_available_sell_qty(req.account_id, req.symbol)
+        if req.qty > available_qty:
+            return {'ok': False, 'reason': 'INSUFFICIENT_POSITION_QTY'}
+        return {'ok': True, 'reason': None}
+
+    return {'ok': False, 'reason': 'INVALID_SIDE'}

--- a/tests/test_risk_policy.py
+++ b/tests/test_risk_policy.py
@@ -1,0 +1,31 @@
+import unittest
+
+from app.schemas.risk import RiskCheckRequest
+from app.services.risk_policy import evaluate_side_policy
+
+
+class RiskPolicyTest(unittest.TestCase):
+    def test_buy_notional_limit_exceeded(self):
+        result = evaluate_side_policy(
+            RiskCheckRequest(account_id='A1', symbol='005930', side='BUY', qty=200, price=70000),
+            get_available_sell_qty=lambda _a, _s: 0,
+        )
+        self.assertEqual(result, {'ok': False, 'reason': 'NOTIONAL_LIMIT_EXCEEDED'})
+
+    def test_sell_requires_position_qty(self):
+        result = evaluate_side_policy(
+            RiskCheckRequest(account_id='A1', symbol='005930', side='SELL', qty=2, price=70000),
+            get_available_sell_qty=lambda _a, _s: 1,
+        )
+        self.assertEqual(result, {'ok': False, 'reason': 'INSUFFICIENT_POSITION_QTY'})
+
+    def test_sell_notional_limit_not_applied(self):
+        result = evaluate_side_policy(
+            RiskCheckRequest(account_id='A1', symbol='005930', side='SELL', qty=200, price=70000),
+            get_available_sell_qty=lambda _a, _s: 300,
+        )
+        self.assertEqual(result, {'ok': True, 'reason': None})
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- 분리된 리스크 정책 서비스(`app/services/risk_policy.py`) 추가
- BUY/SELL 사이드별 정책 분리
  - BUY: `NOTIONAL_LIMIT_EXCEEDED` 적용
  - SELL: 보유수량(`get_available_sell_qty`) 기반 `INSUFFICIENT_POSITION_QTY` 적용
- `/v1/risk/check`가 사이드 정책 서비스(`evaluate_side_policy`)를 사용하도록 변경
- 회귀/신규 테스트 추가
  - `tests/test_risk_policy.py` 신규
  - `tests/test_mvp_iteration1.py`에 SELL 정책 검증 2건 추가

## Verification
### 1) Failing evidence (before implementation)
```bash
python3 -m unittest tests/test_risk_policy.py -v
```
- 결과: `ModuleNotFoundError: No module named 'app.services.risk_policy'` (FAILED)

```bash
python3 -m unittest tests/test_mvp_iteration1.py -v
```
- 결과: `test_risk_check_sell_requires_position_qty` FAIL,
  `test_risk_check_sell_notional_limit_not_applied` ERROR (FAILED)

### 2) Passing evidence (after implementation)
```bash
python3 -m unittest tests/test_risk_policy.py -v
```
- 결과: `Ran 3 tests ... OK`

```bash
python3 -m unittest tests/test_mvp_iteration1.py -v
```
- 결과: `Ran 28 tests ... OK`

## Scope check
- Task2 범위 외 변경 없음
- 주문 실행 어댑터 연동(Task3) 미수행
