### PR TITLE
feat(order): add state-machine retry and metrics

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -131,11 +131,33 @@ def get_order_status(order_id: str):
     job = order_queue.jobs.get(order_id)
     if not job:
         raise HTTPException(status_code=404, detail='order not found')
+
+    status = job['status']
+    if status == 'NEW':
+        status = 'QUEUED'
+
+    return {
+        'order_id': job['order_id'],
+        'status': status,
+        'error': job['error'],
+        'updated_at': job['updated_at'],
+    }
+
+
+@router.get('/orders/{order_id}/state')
+def get_order_state(order_id: str):
+    job = order_queue.jobs.get(order_id)
+    if not job:
+        raise HTTPException(status_code=404, detail='order not found')
+
     return {
         'order_id': job['order_id'],
         'status': job['status'],
         'error': job['error'],
         'updated_at': job['updated_at'],
+        'attempts': job.get('attempts', 0),
+        'max_attempts': job.get('max_attempts', 0),
+        'terminal': job.get('terminal', False),
     }
 
 

--- a/tests/test_order_state_machine.py
+++ b/tests/test_order_state_machine.py
@@ -1,0 +1,90 @@
+import unittest
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.schemas.order import OrderRequest
+from app.services.order_queue import OrderQueue, order_queue
+
+
+class _FlakyAdapter:
+    def __init__(self, failures: int):
+        self.failures = failures
+        self.calls = 0
+
+    def place_order(self, **kwargs):
+        self.calls += 1
+        if self.calls <= self.failures:
+            raise RuntimeError("RATE_LIMIT")
+        return {"broker_order_id": f"broker-{self.calls}"}
+
+
+class OrderStateMachineTest(unittest.TestCase):
+    def setUp(self):
+        self.q = OrderQueue()
+        self.client = TestClient(app)
+        order_queue.queue.clear()
+        order_queue.idem.clear()
+        order_queue.idem_body_hash.clear()
+        order_queue.jobs.clear()
+        order_queue.metrics_counters = {
+            "accepted": 0,
+            "deduplicated": 0,
+            "processed": 0,
+            "sent": 0,
+            "rejected": 0,
+        }
+
+    def test_state_transition_new_sent_filled(self):
+        accepted = self.q.enqueue(OrderRequest(account_id="A1", symbol="005930", side="BUY", qty=1), "idem-1")
+
+        self.assertEqual(self.q.jobs[accepted.order_id]["status"], "NEW")
+
+        sent = self.q.process_next(adapter=_FlakyAdapter(failures=0))
+        self.assertEqual(sent["status"], "SENT")
+
+        final = self.q.mark_execution_result(accepted.order_id, "FILLED")
+        self.assertEqual(final["status"], "FILLED")
+        self.assertTrue(final["terminal"])
+
+    def test_retry_then_success(self):
+        accepted = self.q.enqueue(OrderRequest(account_id="A1", symbol="005930", side="BUY", qty=1), "idem-2")
+        adapter = _FlakyAdapter(failures=2)
+
+        first_status = self.q.process_next(adapter=adapter)["status"]
+        second_status = self.q.process_next(adapter=adapter)["status"]
+        third_status = self.q.process_next(adapter=adapter)["status"]
+
+        self.assertEqual(first_status, "NEW")
+        self.assertEqual(second_status, "NEW")
+        self.assertEqual(third_status, "SENT")
+        self.assertEqual(self.q.jobs[accepted.order_id]["attempts"], 3)
+        self.assertEqual(self.q.metrics()["retried"], 2)
+
+    def test_retry_exhausted_goes_rejected_terminal(self):
+        self.q.enqueue(OrderRequest(account_id="A1", symbol="005930", side="BUY", qty=1), "idem-3")
+        adapter = _FlakyAdapter(failures=99)
+
+        self.q.process_next(adapter=adapter)
+        self.q.process_next(adapter=adapter)
+        last = self.q.process_next(adapter=adapter)
+
+        self.assertEqual(last["status"], "REJECTED")
+        self.assertEqual(last["error"], "RETRY_EXHAUSTED")
+        self.assertTrue(last["terminal"])
+        self.assertEqual(self.q.metrics()["retry_exhausted"], 1)
+
+    def test_order_status_endpoint_exposes_attempts_and_terminal(self):
+        accepted = order_queue.enqueue(OrderRequest(account_id="A1", symbol="005930", side="BUY", qty=1), "idem-api-1")
+        order_queue.jobs[accepted.order_id]["attempts"] = 2
+        order_queue.jobs[accepted.order_id]["terminal"] = False
+
+        r = self.client.get(f"/v1/orders/{accepted.order_id}/state")
+
+        self.assertEqual(r.status_code, 200)
+        self.assertIn("attempts", r.json())
+        self.assertIn("terminal", r.json())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Implemented Task4 order state-machine enhancements in queue processing layer.
- Added explicit lifecycle states and terminal handling:
  - `NEW -> SENT -> FILLED/REJECTED`
- Added retry handling for retryable adapter failures (`RATE_LIMIT`, `UNKNOWN`) with bounded attempts.
- Added observability metrics for retries/finalization.
- Added state-detail read endpoint for attempts/terminal visibility.

## Changed files (Task4 scope only)
- `app/services/order_queue.py`
- `app/api/routes.py`
- `tests/test_order_state_machine.py` (new)

## Verification
### 1) RED (failing tests first)
Command:
```bash
python3 -m unittest -q tests/test_order_state_machine.py
```
Result (before implementation):
- `FAILED (failures=3, errors=1)`
- Key failures:
  - expected `NEW` but got `QUEUED`
  - retry behavior missing (`REJECTED` directly)
  - status payload missing `attempts`/`terminal`

### 2) GREEN (after minimal implementation)
Command:
```bash
python3 -m unittest -q tests/test_order_state_machine.py tests/test_mvp_iteration1.py
```
Result:
- `Ran 32 tests in 0.085s`
- `OK`

## Notes
- Kept legacy `/v1/orders/{order_id}` response contract intact for existing tests/clients.
- Added `/v1/orders/{order_id}/state` for enhanced observability fields (`attempts`, `max_attempts`, `terminal`).
