### PR TITLE
test(order): add buy/sell e2e coverage and runbook evidence

### DIFF
--- a/docs/evidence/2026-02-28-buy-sell-e2e.md
+++ b/docs/evidence/2026-02-28-buy-sell-e2e.md
@@ -1,0 +1,62 @@
+# 2026-02-28 BUY/SELL E2E 검증 증적
+
+## 범위
+- BUY 1건 주문 접수 → 상태조회(`QUEUED`)
+- SELL 1건 주문 접수 → 상태조회(`QUEUED`)
+- 멱등성 시나리오
+  - 동일 `Idempotency-Key` + 동일 Body: deduplicate(동일 `order_id`)
+  - 동일 `Idempotency-Key` + 상이 Body: `409 IDEMPOTENCY_KEY_BODY_MISMATCH`
+
+## 사전 조건
+- 실주문 전송 없음 (in-memory queue 기반 테스트)
+- 테스트 시간은 장중으로 고정(patch: `2026-01-02 10:00:00`)
+- SELL 가능 수량은 테스트 더블로 주입(`get_available_sell_qty=5`)
+
+## 1) Fail-first 증거
+명령:
+```bash
+python3 -m unittest tests/test_order_e2e_buy_sell.py -v
+```
+결과(요약):
+```text
+test_buy_then_status_and_idempotency ... ok
+test_runbook_evidence_and_readme_examples_exist ... FAIL
+test_sell_then_status_and_idempotency_body_mismatch ... ok
+
+FAILED (failures=1)
+AssertionError: False is not true : E2E evidence doc is required
+```
+
+## 2) 최소 구현 반영
+- `tests/test_order_e2e_buy_sell.py` 작성
+  - BUY 주문 + 상태조회 + 동일 key 재호출 dedup 검증
+  - SELL 주문 + 상태조회 + 동일 key 상이 body 충돌(409) 검증
+  - 운영 증적 문서/README 예시 존재 검증
+- `README.md`에 BUY/SELL 주문 실행 + 상태조회 + 멱등성 예시 추가
+- 본 문서(`docs/evidence/2026-02-28-buy-sell-e2e.md`) 생성
+
+## 3) E2E 재실행 PASS 증거
+명령:
+```bash
+python3 -m unittest tests/test_order_e2e_buy_sell.py -v
+```
+결과:
+```text
+test_buy_then_status_and_idempotency ... ok
+test_runbook_evidence_and_readme_examples_exist ... ok
+test_sell_then_status_and_idempotency_body_mismatch ... ok
+
+Ran 3 tests in 0.025s
+OK
+```
+
+## 4) 회귀 일부 실행 PASS 증거
+명령:
+```bash
+python3 -m unittest discover -s tests -v
+```
+결과(요약):
+```text
+Ran 85 tests in 0.256s
+OK
+```

--- a/tests/test_order_e2e_buy_sell.py
+++ b/tests/test_order_e2e_buy_sell.py
@@ -1,0 +1,98 @@
+import unittest
+from datetime import datetime as real_datetime
+from pathlib import Path
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.services.order_queue import order_queue
+
+
+class TestOrderE2EBuySell(unittest.TestCase):
+    def setUp(self):
+        order_queue.queue.clear()
+        order_queue.idem.clear()
+        order_queue.idem_body_hash.clear()
+        order_queue.jobs.clear()
+        order_queue.metrics_counters = {
+            "accepted": 0,
+            "deduplicated": 0,
+            "processed": 0,
+            "sent": 0,
+            "rejected": 0,
+            "filled": 0,
+            "retried": 0,
+            "retry_exhausted": 0,
+            "terminal": 0,
+        }
+        self.client = TestClient(app)
+
+    def test_buy_then_status_and_idempotency(self):
+        body = {
+            "account_id": "A1",
+            "symbol": "005930",
+            "side": "BUY",
+            "qty": 1,
+            "price": 70000,
+            "order_type": "LIMIT",
+        }
+
+        with patch("app.api.routes.datetime") as mock_datetime:
+            mock_datetime.now.return_value = real_datetime(2026, 1, 2, 10, 0, 0)
+            first = self.client.post("/v1/orders", headers={"Idempotency-Key": "e2e-buy-1"}, json=body)
+            second = self.client.post("/v1/orders", headers={"Idempotency-Key": "e2e-buy-1"}, json=body)
+
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(second.status_code, 200)
+
+        order_id = first.json()["order_id"]
+        self.assertEqual(order_id, second.json()["order_id"])
+
+        status = self.client.get(f"/v1/orders/{order_id}")
+        self.assertEqual(status.status_code, 200)
+        self.assertEqual(status.json()["status"], "QUEUED")
+
+    def test_sell_then_status_and_idempotency_body_mismatch(self):
+        sell_body = {
+            "account_id": "A1",
+            "symbol": "005930",
+            "side": "SELL",
+            "qty": 1,
+            "price": 70000,
+            "order_type": "LIMIT",
+        }
+
+        with patch("app.api.routes.datetime") as mock_datetime, patch(
+            "app.api.routes.get_available_sell_qty", return_value=5
+        ):
+            mock_datetime.now.return_value = real_datetime(2026, 1, 2, 10, 0, 0)
+            first = self.client.post("/v1/orders", headers={"Idempotency-Key": "e2e-sell-1"}, json=sell_body)
+            mismatch = self.client.post(
+                "/v1/orders",
+                headers={"Idempotency-Key": "e2e-sell-1"},
+                json={**sell_body, "qty": 2},
+            )
+
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(mismatch.status_code, 409)
+        self.assertEqual(mismatch.json(), {"detail": "IDEMPOTENCY_KEY_BODY_MISMATCH"})
+
+        status = self.client.get(f"/v1/orders/{first.json()['order_id']}")
+        self.assertEqual(status.status_code, 200)
+        self.assertEqual(status.json()["status"], "QUEUED")
+
+    def test_runbook_evidence_and_readme_examples_exist(self):
+        repo_root = Path(__file__).resolve().parents[1]
+        evidence_path = repo_root / "docs" / "evidence" / "2026-02-28-buy-sell-e2e.md"
+        readme_path = repo_root / "README.md"
+
+        self.assertTrue(evidence_path.exists(), "E2E evidence doc is required")
+
+        readme = readme_path.read_text(encoding="utf-8")
+        self.assertIn("BUY 주문 + 상태조회", readme)
+        self.assertIn("SELL 주문 + 상태조회", readme)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `tests/test_order_e2e_buy_sell.py` for BUY/SELL standard flow E2E coverage
- Cover idempotency scenarios:
  - same key + same body => deduplicate (same order_id)
  - same key + different body => 409 `IDEMPOTENCY_KEY_BODY_MISMATCH`
- Add runbook evidence: `docs/evidence/2026-02-28-buy-sell-e2e.md`
- Update `README.md` with BUY/SELL order execution + status lookup examples

## Validation Commands & Results

### 1) Fail-first
```bash
python3 -m unittest tests/test_order_e2e_buy_sell.py -v
```
Result:
- `FAILED (failures=1)`
- `AssertionError: False is not true : E2E evidence doc is required`

### 2) Target test pass
```bash
python3 -m unittest tests/test_order_e2e_buy_sell.py -v
```
Result:
- `Ran 3 tests`
- `OK`

### 3) Regression subset pass
```bash
python3 -m unittest discover -s tests -v
```
Result:
- `Ran 85 tests`
- `OK`

## Scope Guard
- Changed files only:
  - `tests/test_order_e2e_buy_sell.py` (create)
  - `docs/evidence/2026-02-28-buy-sell-e2e.md` (create)
  - `README.md` (modify)
- No live order execution (read-only testing via unittest/TestClient)
