### PR TITLE
docs: risk-first architecture + contract-first plan/API (T1)

### DIFF
--- a/docs/api/openapi-next.yaml
+++ b/docs/api/openapi-next.yaml
@@ -1,0 +1,92 @@
+openapi: 3.0.3
+info:
+  title: KIS Trading Gateway Next API
+  version: 0.1.0-next
+paths:
+  /v1/orders:
+    post:
+      operationId: createOrder
+      summary: Create a new order
+      responses:
+        '200':
+          description: Order accepted
+        '400':
+          description: Contract or risk violation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/orders/{order_id}/cancel:
+    post:
+      operationId: cancelOrder
+      summary: Cancel an existing order
+      parameters:
+        - in: path
+          name: order_id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Cancel accepted
+        '400':
+          description: Invalid transition or request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/orders/{order_id}/modify:
+    post:
+      operationId: modifyOrder
+      summary: Modify an existing order
+      parameters:
+        - in: path
+          name: order_id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Modify accepted
+        '400':
+          description: Invalid transition or request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/balances:
+    get:
+      operationId: getBalances
+      summary: Retrieve account balances
+      responses:
+        '200':
+          description: Balance list
+  /v1/positions:
+    get:
+      operationId: getPositions
+      summary: Retrieve account positions
+      responses:
+        '200':
+          description: Position list
+  /v1/orders/reconcile:
+    post:
+      operationId: reconcileOrders
+      summary: Reconcile internal and broker order states
+      responses:
+        '200':
+          description: Reconciliation completed
+components:
+  schemas:
+    Error:
+      type: object
+      required:
+        - code
+        - message
+        - retryable
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+        retryable:
+          type: boolean

--- a/docs/architecture/2026-02-28-kis-trading-next-architecture.md
+++ b/docs/architecture/2026-02-28-kis-trading-next-architecture.md
@@ -1,0 +1,60 @@
+# KIS Trading Gateway 확장 구조설계 (Risk-first, Contract-first)
+
+## 목표
+정정/취소 주문, 잔고/포지션 조회, 리컨실리에이션을 기존 구조를 크게 깨지 않고 점진적으로 추가한다. 구현 우선순위는 리스크 가드 강화를 최상위로 둔다.
+
+## 설계 원칙
+- Contract-first: OpenAPI 확정 → 테스트 작성 → 구현
+- Risk-first: 주문 경로의 검증/차단 정책을 기능 추가보다 먼저 반영
+- Incremental: 기존 `app/api`, `app/services`, `app/integrations` 구조 유지
+- Idempotent-by-default: 주문/정정/취소 모두 멱등키 기반
+
+## 컴포넌트 경계
+1. API Layer (`app/api/routes.py`)
+   - 계약 검증(필수 필드, enum, 상태 가능 전이)
+   - 에러 매핑(400/409/422/503)
+2. Domain Service Layer (`app/services/*`)
+   - `order_queue`: 상태 전이, 재시도, terminal 처리
+   - `risk_policy`: side/time/notional/position 기반 정책
+   - `reconciliation`: 브로커 상태와 내부 상태 비교/보정
+3. Broker Adapter Layer (`app/integrations/kis_rest.py`, `kis_ws.py`)
+   - KIS API 호출/응답 정규화
+   - 에러 코드 분류(RATE_LIMIT/AUTH/INVALID_ORDER)
+4. Persistence/In-memory State
+   - 현재 in-memory 유지, 인터페이스 분리로 저장소 교체 준비
+
+## 데이터 플로우
+1) 주문/정정/취소 요청 수신
+2) 계약 검증 + 리스크 체크
+3) Idempotency-Key 및 body hash 검증
+4) 큐 적재/상태 전이(NEW→DISPATCHING)
+5) KIS REST 호출
+6) 응답 반영(SENT/REJECTED) + 메트릭/감사 로그
+7) 백그라운드 리컨실로 상태 정합성 확인
+
+## 주문 상태 전이(확장)
+- NEW → DISPATCHING → SENT
+- SENT → PARTIAL_FILLED | FILLED | CANCEL_PENDING | MODIFY_PENDING | REJECTED
+- CANCEL_PENDING → CANCELED | REJECTED
+- MODIFY_PENDING → SENT(수정 주문 재진입) | REJECTED
+- FILLED/CANCELED/REJECTED는 terminal
+
+## 실패/재시도/중복방지
+- 재시도 대상: RATE_LIMIT, UNKNOWN(일시 오류)
+- 재시도 비대상: AUTH, INVALID_ORDER
+- 멱등 충돌: 동일 키 + 다른 body는 409
+- 리컨실 작업에서 중복/유실 탐지 시 상태 보정 이벤트 기록
+
+## Mock → Live 안전 가드
+- 기본 환경은 `mock`
+- live는 명시 플래그 + 계좌 화이트리스트 + 최대수량/일일한도 체크 통과 시만 허용
+- live 경로는 dry-run 검증 로그 없으면 배포 차단
+- kill switch(환경변수)로 live 주문 즉시 차단 가능
+
+## API 문서화 전략
+- 타팀 endpoint naming이 달라도 연동 가능하도록 OpenAPI에
+  - operationId
+  - request/response schema
+  - error code contract
+  를 먼저 고정한다.
+- 실제 path는 임시(`x-path-draft`)로 두고 협의 후 매핑 가능하게 설계한다.

--- a/docs/ops/order-api-contract.md
+++ b/docs/ops/order-api-contract.md
@@ -1,7 +1,7 @@
 # Order API Contract (Task 1)
 
-## Endpoint
-- `POST /v1/orders`
+## Existing Endpoint
+- `POST /v1/orders` (`operationId: createOrder`)
 
 ## Request Body
 - `account_id` (string, required)
@@ -27,6 +27,22 @@
 }
 ```
 
+## Next Contract Endpoints (OpenAPI Draft)
+- `POST /v1/orders/{order_id}/cancel` (`operationId: cancelOrder`)
+- `POST /v1/orders/{order_id}/modify` (`operationId: modifyOrder`)
+- `GET /v1/balances` (`operationId: getBalances`)
+- `GET /v1/positions` (`operationId: getPositions`)
+- `POST /v1/orders/reconcile` (`operationId: reconcileOrders`)
+
+## Error schema
+```json
+{
+  "code": "INVALID_TRANSITION",
+  "message": "Order cannot be modified in current state",
+  "retryable": false
+}
+```
+
 ## Error Codes
 - `INVALID_QTY`
 - `INVALID_PRICE`
@@ -37,6 +53,7 @@
 - `INVALID_ORDER_TYPE`
 - `PRICE_REQUIRED_FOR_LIMIT`
 - `PRICE_NOT_ALLOWED_FOR_MARKET`
+- `INVALID_TRANSITION`
 
 ## Error Mapping
 - `400`: contract/risk violations

--- a/docs/plans/2026-02-28-kis-next-features-implementation.md
+++ b/docs/plans/2026-02-28-kis-next-features-implementation.md
@@ -1,0 +1,177 @@
+# KIS Next Features (Risk-first, Contract-first) Implementation Plan
+
+> REQUIRED EXECUTION SKILL: `executing-plans`
+
+**Goal:** 리스크 우선 정책을 반영한 주문 확장(정정/취소), 잔고/포지션 조회, 리컨실리에이션 기능을 계약 기반으로 안전하게 추가한다.
+**Architecture:** 기존 FastAPI + service/adaptor 구조를 유지하며, OpenAPI 계약을 먼저 확정하고 테스트를 통해 상태전이/에러코드/멱등성을 잠근다. 타팀 엔드포인트 명명은 별도 매핑 가능하도록 스키마와 operationId 중심으로 문서화한다.
+**Tech Stack:** FastAPI, Pydantic, unittest, existing KIS REST/WS adapters
+
+---
+
+### Task 1: OpenAPI 계약 초안(리스크 + 확장 주문) 고정
+
+**Files**
+- Create: `docs/api/openapi-next.yaml`
+- Modify: `docs/ops/order-api-contract.md`
+- Test: `tests/test_api_contract_next.py`
+
+**Step 1 — Failing test**
+```python
+# tests/test_api_contract_next.py
+# openapi-next.yaml 존재 + 필수 schema/operationId/assert
+```
+
+**Step 2 — Verify fail**
+Run: `python3 -m unittest tests.test_api_contract_next -v`
+Expect: `FAIL (file/schema missing)`
+
+**Step 3 — Minimal implementation**
+- openapi에 아래 operationId/schema 추가
+  - createOrder, cancelOrder, modifyOrder, getBalances, getPositions, reconcileOrders
+  - Error schema(code, message, retryable)
+
+**Step 4 — Verify pass**
+Run: `python3 -m unittest tests.test_api_contract_next -v`
+Expect: `OK`
+
+**Step 5 — Checkpoint**
+Run: `git add docs/api/openapi-next.yaml docs/ops/order-api-contract.md tests/test_api_contract_next.py && git commit -m "docs: add contract-first openapi for next KIS features"`
+
+### Task 2: 리스크 정책 확장 (주문/정정/취소 공통 가드)
+
+**Files**
+- Modify: `app/services/risk_policy.py`
+- Modify: `app/api/routes.py`
+- Test: `tests/test_risk_policy_extended.py`
+
+**Step 1 — Failing test**
+- live 주문 차단 플래그, 일일 주문횟수, 최대수량, 정정/취소 가능 상태 검증 테스트 추가
+
+**Step 2 — Verify fail**
+Run: `python3 -m unittest tests.test_risk_policy_extended -v`
+Expect: `FAIL`
+
+**Step 3 — Minimal implementation**
+- 리스크 결과코드 추가: `LIVE_DISABLED`, `DAILY_LIMIT_EXCEEDED`, `INVALID_TRANSITION`
+- 주문/정정/취소에 공통 risk check 적용
+
+**Step 4 — Verify pass**
+Run: `python3 -m unittest tests.test_risk_policy_extended -v`
+Expect: `OK`
+
+**Step 5 — Checkpoint**
+Run: `git add app/services/risk_policy.py app/api/routes.py tests/test_risk_policy_extended.py && git commit -m "feat: extend risk guard for order modify/cancel"`
+
+### Task 3: 정정/취소 주문 API + 상태전이 추가
+
+**Files**
+- Modify: `app/services/order_queue.py`
+- Modify: `app/api/routes.py`
+- Modify: `app/integrations/kis_rest.py`
+- Test: `tests/test_order_modify_cancel_flow.py`
+
+**Step 1 — Failing test**
+- `POST /v1/orders/{order_id}/cancel`
+- `POST /v1/orders/{order_id}/modify`
+- 상태전이 위반 시 400/409 테스트
+
+**Step 2 — Verify fail**
+Run: `python3 -m unittest tests.test_order_modify_cancel_flow -v`
+Expect: `FAIL`
+
+**Step 3 — Minimal implementation**
+- 상태 추가: `CANCEL_PENDING`, `MODIFY_PENDING`, `CANCELED`
+- KIS adapter 메서드 추가(취소/정정 요청)
+
+**Step 4 — Verify pass**
+Run: `python3 -m unittest tests.test_order_modify_cancel_flow -v`
+Expect: `OK`
+
+**Step 5 — Checkpoint**
+Run: `git add app/services/order_queue.py app/api/routes.py app/integrations/kis_rest.py tests/test_order_modify_cancel_flow.py && git commit -m "feat: add order cancel/modify flow with state transitions"`
+
+### Task 4: 잔고/포지션 조회 API 추가
+
+**Files**
+- Modify: `app/integrations/kis_rest.py`
+- Modify: `app/api/routes.py`
+- Create: `app/schemas/portfolio.py`
+- Test: `tests/test_balance_position_endpoints.py`
+
+**Step 1 — Failing test**
+- `/v1/balances`, `/v1/positions` 응답 스키마 테스트
+
+**Step 2 — Verify fail**
+Run: `python3 -m unittest tests.test_balance_position_endpoints -v`
+Expect: `FAIL`
+
+**Step 3 — Minimal implementation**
+- KIS 잔고/보유종목 조회 응답 정규화
+- Pydantic schema로 응답 계약 고정
+
+**Step 4 — Verify pass**
+Run: `python3 -m unittest tests.test_balance_position_endpoints -v`
+Expect: `OK`
+
+**Step 5 — Checkpoint**
+Run: `git add app/integrations/kis_rest.py app/api/routes.py app/schemas/portfolio.py tests/test_balance_position_endpoints.py && git commit -m "feat: add balances/positions endpoints"`
+
+### Task 5: 리컨실리에이션 워커 추가
+
+**Files**
+- Create: `app/services/reconciliation.py`
+- Modify: `app/main.py`
+- Test: `tests/test_reconciliation_worker.py`
+
+**Step 1 — Failing test**
+- 내부 주문 상태 vs 브로커 상태 diff 검출/보정 테스트
+
+**Step 2 — Verify fail**
+Run: `python3 -m unittest tests.test_reconciliation_worker -v`
+Expect: `FAIL`
+
+**Step 3 — Minimal implementation**
+- 주기 워커 추가(초기: 수동 트리거 가능)
+- 불일치 이벤트 메트릭/로그 기록
+
+**Step 4 — Verify pass**
+Run: `python3 -m unittest tests.test_reconciliation_worker -v`
+Expect: `OK`
+
+**Step 5 — Checkpoint**
+Run: `git add app/services/reconciliation.py app/main.py tests/test_reconciliation_worker.py && git commit -m "feat: add reconciliation worker for order consistency"`
+
+### Task 6: 회귀 검증 + 문서 동기화
+
+**Files**
+- Modify: `README.md`
+- Modify: `docs/ops/kis-quote-runbook.md`
+- Test: `tests/test_smoke.py`
+
+**Step 1 — Failing test**
+- 신규 API가 README/runbook에 명시되었는지 문서 검증 테스트 추가
+
+**Step 2 — Verify fail**
+Run: `python3 -m unittest tests.test_smoke -v`
+Expect: `FAIL`
+
+**Step 3 — Minimal implementation**
+- 실행 예시/에러코드/운영 체크리스트 업데이트
+
+**Step 4 — Verify pass**
+Run: `python3 -m unittest discover -s tests -v`
+Expect: `OK`
+
+**Step 5 — Checkpoint**
+Run: `git add README.md docs/ops/kis-quote-runbook.md tests/test_smoke.py && git commit -m "docs: sync runbook and readme for next features"`
+
+---
+
+## 실행 모드 선택
+1) 현재 세션에서 순차 실행 (Task 1부터)
+2) 서브에이전트 위임 실행 (coder 구현 + qa 검증, task 단위 PR)
+
+## 완료 기준
+- Task 1~6 모두 검증 PASS
+- 문서(OpenAPI/Runbook)와 코드 동작 일치
+- 리스크 가드가 live 경로에서 기본 차단/제한 정책을 보장

--- a/tests/test_api_contract_next.py
+++ b/tests/test_api_contract_next.py
@@ -1,0 +1,60 @@
+import pathlib
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+OPENAPI_PATH = REPO_ROOT / "docs" / "api" / "openapi-next.yaml"
+ORDER_CONTRACT_DOC_PATH = REPO_ROOT / "docs" / "ops" / "order-api-contract.md"
+
+
+class TestApiContractNext(unittest.TestCase):
+    def test_openapi_next_exists(self):
+        self.assertTrue(
+            OPENAPI_PATH.exists(),
+            "docs/api/openapi-next.yaml must exist",
+        )
+
+    def test_openapi_next_contains_required_operations_and_error_schema(self):
+        content = OPENAPI_PATH.read_text(encoding="utf-8")
+
+        required_operation_ids = [
+            "createOrder",
+            "cancelOrder",
+            "modifyOrder",
+            "getBalances",
+            "getPositions",
+            "reconcileOrders",
+        ]
+        for operation_id in required_operation_ids:
+            self.assertIn(f"operationId: {operation_id}", content)
+
+        self.assertIn("Error:", content)
+        self.assertIn("code:", content)
+        self.assertIn("message:", content)
+        self.assertIn("retryable:", content)
+
+    def test_order_api_contract_doc_mentions_next_operations(self):
+        content = ORDER_CONTRACT_DOC_PATH.read_text(encoding="utf-8")
+
+        expected_snippets = [
+            "POST /v1/orders/{order_id}/cancel",
+            "POST /v1/orders/{order_id}/modify",
+            "GET /v1/balances",
+            "GET /v1/positions",
+            "POST /v1/orders/reconcile",
+            "createOrder",
+            "cancelOrder",
+            "modifyOrder",
+            "getBalances",
+            "getPositions",
+            "reconcileOrders",
+            "Error schema",
+            "retryable",
+        ]
+
+        for snippet in expected_snippets:
+            self.assertIn(snippet, content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add risk-first architecture doc for next KIS features
- add contract-first implementation plan (Task 1~6)
- add OpenAPI next draft contract and contract test
- update order API contract doc with next-scope operations

## Verification
- python3 -m unittest tests.test_api_contract_next -v
- result: PASS (3 tests)

## Notes
- scope is documentation/contract baseline for next implementation cycle
- endpoint naming may be finalized by the integration team; operationId/schema are fixed first
