### PR TITLE
feat: T2 risk guard extension with transition checks

### DIFF
--- a/docs/api/openapi-next.yaml
+++ b/docs/api/openapi-next.yaml
@@ -2,14 +2,27 @@ openapi: 3.0.3
 info:
   title: KIS Trading Gateway Next API
   version: 0.1.0-next
+  description: >-
+    Contract-first spec. Clients should integrate by operationId and schemas.
+    Endpoint path naming may evolve while operationId + request/response schemas remain backward-compatible.
 paths:
   /v1/orders:
     post:
       operationId: createOrder
       summary: Create a new order
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrderCreateRequest'
       responses:
         '200':
           description: Order accepted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrderAccepted'
         '400':
           description: Contract or risk violation
           content:
@@ -29,6 +42,10 @@ paths:
       responses:
         '200':
           description: Cancel accepted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrderAccepted'
         '400':
           description: Invalid transition or request
           content:
@@ -45,9 +62,19 @@ paths:
           required: true
           schema:
             type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrderModifyRequest'
       responses:
         '200':
           description: Modify accepted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrderAccepted'
         '400':
           description: Invalid transition or request
           content:
@@ -61,6 +88,12 @@ paths:
       responses:
         '200':
           description: Balance list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Balance'
   /v1/positions:
     get:
       operationId: getPositions
@@ -68,6 +101,12 @@ paths:
       responses:
         '200':
           description: Position list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Position'
   /v1/orders/reconcile:
     post:
       operationId: reconcileOrders
@@ -75,8 +114,64 @@ paths:
       responses:
         '200':
           description: Reconciliation completed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReconcileResult'
 components:
   schemas:
+    OrderCreateRequest:
+      type: object
+      required:
+        - account_id
+        - symbol
+        - side
+        - qty
+      properties:
+        account_id:
+          type: string
+        symbol:
+          type: string
+        side:
+          type: string
+          enum: [BUY, SELL]
+        qty:
+          type: integer
+          minimum: 1
+        order_type:
+          type: string
+          enum: [LIMIT, MARKET]
+          default: LIMIT
+        price:
+          type: number
+          nullable: true
+        strategy_id:
+          type: string
+          nullable: true
+    OrderModifyRequest:
+      type: object
+      required:
+        - qty
+      properties:
+        qty:
+          type: integer
+          minimum: 1
+        price:
+          type: number
+          nullable: true
+    OrderAccepted:
+      type: object
+      required:
+        - order_id
+        - status
+        - idempotency_key
+      properties:
+        order_id:
+          type: string
+        status:
+          type: string
+        idempotency_key:
+          type: string
     Error:
       type: object
       required:
@@ -86,7 +181,48 @@ components:
       properties:
         code:
           type: string
+          enum:
+            - INVALID_QTY
+            - INVALID_PRICE
+            - INVALID_SIDE
+            - NOTIONAL_LIMIT_EXCEEDED
+            - INSUFFICIENT_POSITION_QTY
+            - OUT_OF_TRADING_WINDOW
+            - LIVE_DISABLED
+            - DAILY_LIMIT_EXCEEDED
+            - MAX_QTY_EXCEEDED
+            - INVALID_TRANSITION
         message:
           type: string
         retryable:
           type: boolean
+    Balance:
+      type: object
+      required: [account_id, currency, cash_available]
+      properties:
+        account_id:
+          type: string
+        currency:
+          type: string
+        cash_available:
+          type: number
+    Position:
+      type: object
+      required: [account_id, symbol, qty]
+      properties:
+        account_id:
+          type: string
+        symbol:
+          type: string
+        qty:
+          type: integer
+    ReconcileResult:
+      type: object
+      required: [checked, mismatched, updated]
+      properties:
+        checked:
+          type: integer
+        mismatched:
+          type: integer
+        updated:
+          type: integer

--- a/tests/test_risk_policy_extended.py
+++ b/tests/test_risk_policy_extended.py
@@ -1,0 +1,70 @@
+import unittest
+from datetime import datetime as real_datetime
+from unittest.mock import patch
+
+from fastapi import HTTPException
+
+from app.api import routes
+from app.schemas.risk import RiskCheckRequest
+from app.services import risk_policy
+
+
+class RiskPolicyExtendedTest(unittest.TestCase):
+    def test_evaluate_trade_risk_blocks_live_when_disabled(self):
+        req = RiskCheckRequest(account_id='A1', symbol='005930', side='BUY', qty=1, price=70000)
+        result = risk_policy.evaluate_trade_risk(
+            req,
+            live_enabled=False,
+            daily_order_count=0,
+            daily_order_limit=5,
+            max_qty=10,
+            get_available_sell_qty=lambda _a, _s: 0,
+        )
+        self.assertEqual(result, {'ok': False, 'reason': 'LIVE_DISABLED'})
+
+    def test_evaluate_trade_risk_blocks_daily_limit(self):
+        req = RiskCheckRequest(account_id='A1', symbol='005930', side='BUY', qty=1, price=70000)
+        result = risk_policy.evaluate_trade_risk(
+            req,
+            live_enabled=True,
+            daily_order_count=5,
+            daily_order_limit=5,
+            max_qty=10,
+            get_available_sell_qty=lambda _a, _s: 0,
+        )
+        self.assertEqual(result, {'ok': False, 'reason': 'DAILY_LIMIT_EXCEEDED'})
+
+    def test_evaluate_trade_risk_blocks_max_qty(self):
+        req = RiskCheckRequest(account_id='A1', symbol='005930', side='BUY', qty=11, price=70000)
+        result = risk_policy.evaluate_trade_risk(
+            req,
+            live_enabled=True,
+            daily_order_count=0,
+            daily_order_limit=5,
+            max_qty=10,
+            get_available_sell_qty=lambda _a, _s: 0,
+        )
+        self.assertEqual(result, {'ok': False, 'reason': 'MAX_QTY_EXCEEDED'})
+
+    def test_validate_order_action_transition(self):
+        ok = risk_policy.validate_order_action_transition(action='cancel', current_status='SENT')
+        blocked = risk_policy.validate_order_action_transition(action='modify', current_status='FILLED')
+        self.assertEqual(ok, {'ok': True, 'reason': None})
+        self.assertEqual(blocked, {'ok': False, 'reason': 'INVALID_TRANSITION'})
+
+    def test_route_transition_guard_raises_http_400(self):
+        with self.assertRaises(HTTPException) as ctx:
+            routes._ensure_transition_allowed(current_status='FILLED', action='cancel')
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertEqual(ctx.exception.detail, 'INVALID_TRANSITION')
+
+    def test_route_check_risk_uses_extended_guard(self):
+        req = RiskCheckRequest(account_id='A1', symbol='005930', side='BUY', qty=1, price=70000)
+        with patch('app.api.routes.datetime') as mock_datetime:
+            mock_datetime.now.return_value = real_datetime(2026, 1, 2, 10, 0, 0)
+            result = routes.check_risk(req)
+        self.assertEqual(result, {'ok': True, 'reason': None})
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
Implements Task 2 with PR #53 risk feedback:
- Hardened risk guard policy for live flag / daily limit / max qty
- Added modify/cancel transition guard helper (`INVALID_TRANSITION`)
- Kept endpoint naming flexible by hardening OpenAPI around `operationId` and schema contracts

## Changed Files
- `app/services/risk_policy.py`
- `app/api/routes.py`
- `tests/test_risk_policy_extended.py`
- `docs/api/openapi-next.yaml`

## Command / Result / Verdict
1. `python3 -m unittest tests.test_risk_policy_extended -v`
   - Result: `OK (6 tests)`
   - Verdict: PASS
2. `python3 -m unittest tests.test_order_e2e_buy_sell tests.test_order_state_machine -v`
   - Result: `OK (7 tests)`
   - Verdict: PASS
3. `python3 -m unittest tests.test_api_contract_next tests.test_risk_policy_extended tests.test_order_e2e_buy_sell tests.test_order_state_machine -v`
   - Result: `OK (16 tests)`
   - Verdict: PASS

## Risks
- Daily order counter is currently in-memory process state (`_daily_order_count`), so restart resets count and multi-worker consistency is not guaranteed.
- Transition guard helper is wired for shared use and tested, but modify/cancel endpoints are still pending Task 3 integration.
- OpenAPI `Error.code` enum is hardened for known T2 codes; future broker-specific codes may require additive updates.
