### PR TITLE
feat: Task 3 order modify/cancel API and state transitions

### DIFF
--- a/app/services/order_queue.py
+++ b/app/services/order_queue.py
@@ -172,6 +172,32 @@ class OrderQueue:
             return None
         return str(job["status"])
 
+    def request_cancel(self, order_id: str) -> dict:
+        job = self.jobs.get(order_id)
+        if not job:
+            raise KeyError("ORDER_NOT_FOUND")
+        if job.get("terminal"):
+            raise RuntimeError("ORDER_ALREADY_TERMINAL")
+
+        job["status"] = "CANCEL_PENDING"
+        job["updated_at"] = int(time.time())
+        return job
+
+    def request_modify(self, order_id: str, *, qty: int, price: float | None = None) -> dict:
+        job = self.jobs.get(order_id)
+        if not job:
+            raise KeyError("ORDER_NOT_FOUND")
+        if job.get("terminal"):
+            raise RuntimeError("ORDER_ALREADY_TERMINAL")
+
+        request_payload = job.get("request", {})
+        request_payload["qty"] = qty
+        request_payload["price"] = price
+
+        job["status"] = "MODIFY_PENDING"
+        job["updated_at"] = int(time.time())
+        return job
+
     def metrics(self) -> dict:
         base = {
             "accepted": 0,

--- a/tests/test_order_modify_cancel_flow.py
+++ b/tests/test_order_modify_cancel_flow.py
@@ -1,0 +1,78 @@
+import unittest
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.schemas.order import OrderRequest
+from app.services.order_queue import order_queue
+
+
+class TestOrderModifyCancelFlow(unittest.TestCase):
+    def setUp(self):
+        order_queue.queue.clear()
+        order_queue.idem.clear()
+        order_queue.idem_body_hash.clear()
+        order_queue.jobs.clear()
+        order_queue.metrics_counters = {
+            "accepted": 0,
+            "deduplicated": 0,
+            "processed": 0,
+            "sent": 0,
+            "rejected": 0,
+            "filled": 0,
+            "retried": 0,
+            "retry_exhausted": 0,
+            "terminal": 0,
+        }
+        self.client = TestClient(app)
+
+    def test_cancel_order_transitions_to_cancel_pending(self):
+        accepted = order_queue.enqueue(OrderRequest(account_id="A1", symbol="005930", side="BUY", qty=1), "idem-cancel-1")
+
+        resp = self.client.post(f"/v1/orders/{accepted.order_id}/cancel")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["order_id"], accepted.order_id)
+        self.assertEqual(order_queue.jobs[accepted.order_id]["status"], "CANCEL_PENDING")
+
+    def test_modify_order_transitions_to_modify_pending_and_updates_request(self):
+        accepted = order_queue.enqueue(OrderRequest(account_id="A1", symbol="005930", side="BUY", qty=1, price=70000), "idem-modify-1")
+        order_queue.jobs[accepted.order_id]["status"] = "SENT"
+
+        resp = self.client.post(
+            f"/v1/orders/{accepted.order_id}/modify",
+            json={"qty": 2, "price": 69900},
+        )
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["order_id"], accepted.order_id)
+        self.assertEqual(order_queue.jobs[accepted.order_id]["status"], "MODIFY_PENDING")
+        self.assertEqual(order_queue.jobs[accepted.order_id]["request"]["qty"], 2)
+        self.assertEqual(order_queue.jobs[accepted.order_id]["request"]["price"], 69900)
+
+    def test_cancel_invalid_transition_returns_400(self):
+        accepted = order_queue.enqueue(OrderRequest(account_id="A1", symbol="005930", side="BUY", qty=1), "idem-cancel-2")
+        order_queue.jobs[accepted.order_id]["status"] = "FILLED"
+        order_queue.jobs[accepted.order_id]["terminal"] = False
+
+        resp = self.client.post(f"/v1/orders/{accepted.order_id}/cancel")
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.json(), {"detail": "INVALID_TRANSITION"})
+
+    def test_modify_terminal_order_returns_409(self):
+        accepted = order_queue.enqueue(OrderRequest(account_id="A1", symbol="005930", side="BUY", qty=1, price=70000), "idem-modify-2")
+        order_queue.jobs[accepted.order_id]["status"] = "CANCELED"
+        order_queue.jobs[accepted.order_id]["terminal"] = True
+
+        resp = self.client.post(
+            f"/v1/orders/{accepted.order_id}/modify",
+            json={"qty": 3, "price": 69800},
+        )
+
+        self.assertEqual(resp.status_code, 409)
+        self.assertEqual(resp.json(), {"detail": "ORDER_ALREADY_TERMINAL"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Added cancel/modify order API endpoints and state transitions for Task 3.
- Added KIS REST adapter methods for cancel/modify requests.
- Added dedicated RED→GREEN tests for modify/cancel flow.

## Command
1. `python3 -m unittest tests.test_order_modify_cancel_flow -v` (RED)
2. `python3 -m unittest tests.test_order_modify_cancel_flow -v` (GREEN)
3. `python3 -m unittest tests.test_order_e2e_buy_sell tests.test_order_state_machine tests.test_risk_policy_extended -v`

## Result
1. RED confirmed initially: 4 failures (404 for missing modify/cancel endpoints).
2. GREEN after minimal implementation: all 4 tests pass.
3. Regression suite: all 13 tests pass.

## Verdict
PASS

## Risks
- KIS `order-rvsecncl` TR IDs and payload mapping are implemented from current assumptions and are not yet end-to-end validated against real broker environment.
- Cancel/modify endpoints currently update internal queue state; broker-side async confirmation/state reconciliation remains follow-up scope.
