### PR TITLE
feat: add reconciliation worker for order consistency

### DIFF
--- a/app/services/reconciliation.py
+++ b/app/services/reconciliation.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import threading
+import time
+from typing import Callable
+
+
+class ReconciliationService:
+    def __init__(
+        self,
+        *,
+        order_queue,
+        broker_status_provider: Callable[[str, dict], str | None] | None = None,
+        interval_sec: float = 5.0,
+    ) -> None:
+        self.order_queue = order_queue
+        self.broker_status_provider = broker_status_provider or (lambda _order_id, _job: None)
+        self.interval_sec = interval_sec
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._metrics = {
+            "runs": 0,
+            "checked": 0,
+            "mismatched": 0,
+            "corrected": 0,
+        }
+        self._recent_events: list[dict] = []
+
+    def _record_event(self, event: dict) -> None:
+        self._recent_events.append(event)
+        if len(self._recent_events) > 100:
+            self._recent_events = self._recent_events[-100:]
+
+    def _apply_correction(self, *, job: dict, broker_status: str) -> str:
+        corrected_status = broker_status
+        terminal_states = {"FILLED", "REJECTED", "CANCELED"}
+
+        job["status"] = corrected_status
+        if corrected_status in terminal_states:
+            job["terminal"] = True
+            if corrected_status == "FILLED":
+                job["error"] = None
+            elif corrected_status == "REJECTED":
+                job["error"] = job.get("error") or "BROKER_REJECTED"
+            else:
+                job["error"] = None
+        job["updated_at"] = int(time.time())
+        return corrected_status
+
+    def reconcile_once(self) -> dict:
+        checked = 0
+        mismatched = 0
+        corrected = 0
+        events: list[dict] = []
+
+        for order_id, job in list(self.order_queue.jobs.items()):
+            checked += 1
+            broker_status = self.broker_status_provider(order_id, job)
+            if not broker_status:
+                continue
+
+            internal_status = str(job.get("status", "UNKNOWN"))
+            normalized_broker = str(broker_status).upper()
+            if internal_status == normalized_broker:
+                continue
+
+            mismatched += 1
+            corrected_status = self._apply_correction(job=job, broker_status=normalized_broker)
+            corrected += 1
+            event = {
+                "order_id": order_id,
+                "internal_status": internal_status,
+                "broker_status": normalized_broker,
+                "corrected_status": corrected_status,
+                "ts": int(time.time()),
+            }
+            events.append(event)
+            self._record_event(event)
+
+        self._metrics["runs"] += 1
+        self._metrics["checked"] += checked
+        self._metrics["mismatched"] += mismatched
+        self._metrics["corrected"] += corrected
+
+        return {
+            "checked": checked,
+            "mismatched": mismatched,
+            "corrected": corrected,
+            "events": events,
+        }
+
+    def trigger(self) -> dict:
+        return self.reconcile_once()
+
+    def _loop(self) -> None:
+        while not self._stop_event.wait(self.interval_sec):
+            try:
+                self.reconcile_once()
+            except Exception:  # pragma: no cover
+                continue
+
+    def start(self) -> None:
+        if self._thread and self._thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._loop, daemon=True, name="reconciliation-worker")
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=1.0)
+
+    def metrics(self) -> dict:
+        return {
+            **self._metrics,
+            "recent_events": list(self._recent_events),
+        }

--- a/tests/test_reconciliation_worker.py
+++ b/tests/test_reconciliation_worker.py
@@ -1,0 +1,89 @@
+import unittest
+from unittest.mock import Mock
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.schemas.order import OrderRequest
+from app.services.order_queue import order_queue
+from app.services.reconciliation import ReconciliationService
+
+
+class TestReconciliationService(unittest.TestCase):
+    def setUp(self):
+        order_queue.queue.clear()
+        order_queue.idem.clear()
+        order_queue.idem_body_hash.clear()
+        order_queue.jobs.clear()
+
+    def test_reconcile_detects_diff_and_corrects_terminal_status(self):
+        accepted = order_queue.enqueue(
+            OrderRequest(account_id="A1", symbol="005930", side="BUY", qty=1, price=70000),
+            "idem-reconcile-1",
+        )
+        order_queue.jobs[accepted.order_id]["status"] = "SENT"
+
+        worker = ReconciliationService(
+            order_queue=order_queue,
+            broker_status_provider=lambda _order_id, _job: "FILLED",
+        )
+
+        result = worker.reconcile_once()
+
+        self.assertEqual(result["checked"], 1)
+        self.assertEqual(result["mismatched"], 1)
+        self.assertEqual(result["corrected"], 1)
+        self.assertEqual(order_queue.jobs[accepted.order_id]["status"], "FILLED")
+        self.assertTrue(order_queue.jobs[accepted.order_id]["terminal"])
+
+        event = result["events"][0]
+        self.assertEqual(event["order_id"], accepted.order_id)
+        self.assertEqual(event["internal_status"], "SENT")
+        self.assertEqual(event["broker_status"], "FILLED")
+        self.assertEqual(event["corrected_status"], "FILLED")
+
+    def test_reconcile_skips_when_status_is_same(self):
+        accepted = order_queue.enqueue(
+            OrderRequest(account_id="A1", symbol="005930", side="BUY", qty=1, price=70000),
+            "idem-reconcile-2",
+        )
+        order_queue.jobs[accepted.order_id]["status"] = "SENT"
+
+        worker = ReconciliationService(
+            order_queue=order_queue,
+            broker_status_provider=lambda _order_id, _job: "SENT",
+        )
+
+        result = worker.reconcile_once()
+
+        self.assertEqual(result["checked"], 1)
+        self.assertEqual(result["mismatched"], 0)
+        self.assertEqual(result["corrected"], 0)
+        self.assertEqual(result["events"], [])
+
+
+class TestMainWiringForReconciliationWorker(unittest.TestCase):
+    def test_lifespan_calls_reconciliation_worker_start_and_stop(self):
+        worker = app.state.reconciliation_worker
+        original_start = worker.start
+        original_stop = worker.stop
+
+        start_mock = Mock()
+        stop_mock = Mock()
+
+        worker.start = start_mock
+        worker.stop = stop_mock
+
+        try:
+            with TestClient(app):
+                start_mock.assert_called_once_with()
+                stop_mock.assert_not_called()
+
+            stop_mock.assert_called_once_with()
+        finally:
+            worker.start = original_start
+            worker.stop = original_stop
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Added in-memory reconciliation worker service that compares internal order status vs broker status and applies corrective updates.
- Wired reconciliation worker lifecycle into FastAPI app startup/shutdown.
- Added worker-focused tests for diff detection/correction and app lifespan wiring.

## Command
1. `python3 -m unittest tests.test_reconciliation_worker -v`
2. `python3 -m unittest tests.test_balance_position_endpoints tests.test_order_modify_cancel_flow tests.test_risk_policy_extended -v`

## Result
1. `OK` (3 tests)
2. `OK` (12 tests)

## Verdict
PASS

## Risks
- Current broker status provider default is no-op; production adapter wiring for real broker polling is still needed.
- Reconciliation events are kept in-memory (recent 100); not persisted across process restart.
- Reconciliation currently performs whole in-memory scan; scale/perf tuning may be needed for larger order volumes.
