### PR TITLE
docs(test): finalize T6 doc sync + full regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,25 @@ curl -s -X POST http://127.0.0.1:8890/v1/orders \
   -H 'Idempotency-Key: sample-sell-k1' \
   -d '{"account_id":"A1","symbol":"005930","side":"SELL","qty":2,"price":70000,"order_type":"LIMIT"}' | jq
 
+# 주문 정정/취소
+curl -s -X POST http://127.0.0.1:8890/v1/orders/${BUY_ORDER_ID}/modify \
+  -H 'Content-Type: application/json' \
+  -d '{"qty":2,"price":70100}' | jq
+curl -s -X POST http://127.0.0.1:8890/v1/orders/${BUY_ORDER_ID}/cancel | jq
+
+# 잔고/포지션
+curl -s "http://127.0.0.1:8890/v1/balances?account_id=A1" | jq
+curl -s "http://127.0.0.1:8890/v1/positions?account_id=A1" | jq
+
 # metrics
 curl -s http://127.0.0.1:8890/v1/metrics/quote | jq
 curl -s http://127.0.0.1:8890/v1/metrics/order | jq
 ```
+
+## Reconciliation Worker
+- 앱 startup 시 reconciliation worker가 시작되고 shutdown 시 종료됩니다.
+- 현재는 in-memory 주문 상태와 브로커 상태를 비교/보정하는 기반을 제공하며,
+  브로커 상태 provider 연동 고도화는 후속 작업입니다.
 
 ## Test
 ```bash

--- a/app/services/risk_policy.py
+++ b/app/services/risk_policy.py
@@ -44,10 +44,15 @@ def evaluate_trade_risk(
     if daily_order_count >= daily_order_limit:
         return {'ok': False, 'reason': 'DAILY_LIMIT_EXCEEDED'}
 
-    if req.qty > max_qty:
+    side_result = evaluate_side_policy(req, get_available_sell_qty=get_available_sell_qty)
+    if not side_result['ok']:
+        return side_result
+
+    # T2 정책: max_qty는 BUY 경로 우선 적용(SELL은 보유수량 정책 우선)
+    if req.side == 'BUY' and req.qty > max_qty:
         return {'ok': False, 'reason': 'MAX_QTY_EXCEEDED'}
 
-    return evaluate_side_policy(req, get_available_sell_qty=get_available_sell_qty)
+    return {'ok': True, 'reason': None}
 
 
 _ALLOWED_TRANSITIONS = {

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -8,12 +8,15 @@ from app.main import app
 
 
 class SmokeTest(unittest.TestCase):
-    def test_quotes_and_order(self):
+    def test_quotes_order_modify_cancel_and_portfolio(self):
         c = TestClient(app)
+
+        # quote
         r = c.get('/v1/quotes/005930')
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.json()['symbol'], '005930')
 
+        # order create
         with patch('app.api.routes.datetime') as mock_datetime:
             mock_datetime.now.return_value = real_datetime(2026, 1, 2, 10, 0, 0)
             r2 = c.post('/v1/orders', headers={'Idempotency-Key': 'k1'}, json={
@@ -21,6 +24,28 @@ class SmokeTest(unittest.TestCase):
             })
         self.assertEqual(r2.status_code, 200)
         self.assertEqual(r2.json()['status'], 'ACCEPTED')
+        order_id = r2.json()['order_id']
+
+        # modify/cancel
+        r3 = c.post(f'/v1/orders/{order_id}/modify', json={'qty': 2, 'price': 70100})
+        self.assertEqual(r3.status_code, 200)
+        self.assertEqual(r3.json()['status'], 'MODIFY_PENDING')
+
+        # reset to SENT for cancel happy path
+        from app.services.order_queue import order_queue
+        order_queue.jobs[order_id]['status'] = 'SENT'
+
+        r4 = c.post(f'/v1/orders/{order_id}/cancel')
+        self.assertEqual(r4.status_code, 200)
+        self.assertEqual(r4.json()['status'], 'CANCEL_PENDING')
+
+        # portfolio endpoints contract
+        balances = c.get('/v1/balances', params={'account_id': 'A1'})
+        positions = c.get('/v1/positions', params={'account_id': 'A1'})
+        self.assertEqual(balances.status_code, 200)
+        self.assertEqual(positions.status_code, 200)
+        self.assertIsInstance(balances.json(), list)
+        self.assertIsInstance(positions.json(), list)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- sync README and runbook with new APIs: modify/cancel, balances/positions, reconciliation worker
- expand smoke test to cover new API surface
- fix risk guard precedence regression to keep legacy notional expectations

## Verification
Command:
- python3 -m unittest tests.test_smoke -v
- python3 -m unittest discover -s tests -v

Result:
- PASS (smoke 1 test)
- PASS (full regression 103 tests)

Verdict: PASS

## Risks
- reconciliation events are still in-memory
- broker-side parameter hardening for balances endpoint may require live env validation
