### PR TITLE
hardening: fail fast on portfolio provider misconfiguration

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -260,17 +260,17 @@ def modify_order(order_id: str, req: OrderModifyRequest):
 @router.get('/balances', response_model=list[Balance])
 def get_balances(account_id: str, request: Request):
     rest_client = request.app.state.quote_gateway_service.rest_client
-    if hasattr(rest_client, 'get_balances'):
-        return rest_client.get_balances(account_id)
-    return []
+    if not hasattr(rest_client, 'get_balances'):
+        raise HTTPException(status_code=503, detail='PORTFOLIO_PROVIDER_NOT_CONFIGURED')
+    return rest_client.get_balances(account_id)
 
 
 @router.get('/positions', response_model=list[Position])
 def get_positions(account_id: str, request: Request):
     rest_client = request.app.state.quote_gateway_service.rest_client
-    if hasattr(rest_client, 'get_positions'):
-        return rest_client.get_positions(account_id)
-    return []
+    if not hasattr(rest_client, 'get_positions'):
+        raise HTTPException(status_code=503, detail='PORTFOLIO_PROVIDER_NOT_CONFIGURED')
+    return rest_client.get_positions(account_id)
 
 
 @router.get('/metrics/quote')

--- a/tests/test_balance_position_endpoints.py
+++ b/tests/test_balance_position_endpoints.py
@@ -25,6 +25,10 @@ class _PortfolioStubClient:
         ]
 
 
+class _MissingPortfolioProvider:
+    pass
+
+
 class TestBalancePositionEndpoints(unittest.TestCase):
     def setUp(self):
         self.client = TestClient(app)
@@ -53,6 +57,20 @@ class TestBalancePositionEndpoints(unittest.TestCase):
         self.assertEqual(payload[0]["account_id"], "12345678-01")
         self.assertEqual(payload[0]["symbol"], "005930")
         self.assertEqual(payload[0]["qty"], 7)
+
+    def test_get_balances_returns_503_when_provider_not_configured(self):
+        app.state.quote_gateway_service.rest_client = _MissingPortfolioProvider()
+        resp = self.client.get("/v1/balances", params={"account_id": "12345678-01"})
+
+        self.assertEqual(resp.status_code, 503)
+        self.assertEqual(resp.json(), {"detail": "PORTFOLIO_PROVIDER_NOT_CONFIGURED"})
+
+    def test_get_positions_returns_503_when_provider_not_configured(self):
+        app.state.quote_gateway_service.rest_client = _MissingPortfolioProvider()
+        resp = self.client.get("/v1/positions", params={"account_id": "12345678-01"})
+
+        self.assertEqual(resp.status_code, 503)
+        self.assertEqual(resp.json(), {"detail": "PORTFOLIO_PROVIDER_NOT_CONFIGURED"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- return `503 PORTFOLIO_PROVIDER_NOT_CONFIGURED` for `/v1/balances` and `/v1/positions` when provider methods are missing
- add endpoint tests for the misconfiguration case

## Verification
- python3 -m unittest tests.test_balance_position_endpoints -v
