### PR TITLE
docs: add live validation checklist for order flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ curl -s http://127.0.0.1:8890/v1/metrics/quote | jq
 - 인증(token): 토큰 발급/갱신 실패 시 APP_KEY/APP_SECRET 및 환경(mock/live) 재확인
 
 상세 운영 절차: `docs/ops/kis-quote-runbook.md`
+주문 실검증 체크리스트: `docs/ops/kis-order-live-validation-checklist.md`
 
 ## Quick API Check
 ```bash

--- a/docs/ops/kis-order-live-validation-checklist.md
+++ b/docs/ops/kis-order-live-validation-checklist.md
@@ -1,0 +1,52 @@
+# KIS Order Live Validation Checklist
+
+목적: 실브로커 환경에서 주문 연동을 단계적으로 검증하되, 위험을 최소화하고 롤백 가능성을 확보한다.
+
+## 1) 사전 안전 가드 (주문 금지 단계)
+- [ ] `KIS_ENV=live` 외 민감 값(APP_KEY/APP_SECRET/계좌) 마스킹 확인
+- [ ] 운영 공지/변경 윈도우 승인 확인
+- [ ] **주문/정정/취소 API 호출 금지** 원칙 확인
+- [ ] `/v1/session/status`, `/v1/metrics/quote` 정상 응답 확인
+- [ ] WS 연결 지표(`ws_connected`, `last_ws_message_ts`, `ws_heartbeat_fresh`) 정상 확인
+
+## 2) Read-only 점검 증거 캡처
+- [ ] quote 조회 결과(`source`, `price`, `ts`) 캡처
+- [ ] quote metrics 스냅샷(`ws_messages`, `rest_fallbacks`, `ws_reconnect_count`) 캡처
+- [ ] 장애 징후(`ws_last_error`, REST 429, token 실패) 유무 기록
+
+## 3) 제한적 주문 허용 단계 (승인 후)
+- [ ] 운영자 승인 기록(시간/담당자) 확보
+- [ ] 최소 주문 단위(1주) + 제한 심볼 1개로 테스트
+- [ ] Idempotency-Key 고정 및 주문 요청/응답 원문 보관
+- [ ] 주문 상태 조회(`/v1/orders/{order_id}`)로 최종 상태 확인
+- [ ] 필요 시 정정/취소 API 테스트는 별도 승인 후 진행
+
+## 4) 롤백 절차
+1. 신규 주문 트래픽 즉시 중단
+2. 워커/프로세스 재기동으로 WS 상태 초기화
+3. 문제 구간 로그/메트릭 스냅샷 보존
+4. `KIS_ENV=mock` 전환 또는 read-only 모드로 회귀
+5. 원인 분석 전까지 주문 허용 단계 재진입 금지
+
+## 5) 증거 템플릿
+```text
+[Validation Window]
+- Date/Time(KST):
+- Operator:
+- Env: live
+
+[Checks]
+- Session status: PASS/FAIL
+- Quote metrics health: PASS/FAIL
+- Read-only quote capture: PASS/FAIL
+- Limited order validation (if approved): PASS/FAIL
+
+[Incidents]
+- ws_last_error:
+- 429 cooldown observed:
+- token issue observed:
+
+[Decision]
+- GO / NO-GO
+- Follow-up actions:
+```

--- a/docs/ops/kis-quote-runbook.md
+++ b/docs/ops/kis-quote-runbook.md
@@ -132,6 +132,8 @@ curl -s -X POST http://127.0.0.1:8890/v1/orders/{order_id}/cancel | jq
 - terminal 주문 대상 정정/취소는 409
 - 리스크 가드(`LIVE_DISABLED`, `DAILY_LIMIT_EXCEEDED`, `MAX_QTY_EXCEEDED`) 동작 여부 확인
 
+주문 실브로커 검증은 `docs/ops/kis-order-live-validation-checklist.md`를 기준으로 수행한다.
+
 ## 6) 잔고/포지션 조회 체크
 
 ```bash
@@ -141,7 +143,7 @@ curl -s "http://127.0.0.1:8890/v1/positions?account_id=A1" | jq
 
 판단 포인트:
 - 응답은 리스트 스키마 유지
-- KIS 연동 미구성 시 빈 리스트 반환 가능(환경 구성 확인 필요)
+- KIS 연동 미구성 시 `PORTFOLIO_PROVIDER_NOT_CONFIGURED`(HTTP 503) 반환
 
 ## 7) Reconciliation 워커 체크
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,5 +1,6 @@
 import unittest
 from datetime import datetime as real_datetime
+from pathlib import Path
 from unittest.mock import patch
 
 from fastapi.testclient import TestClient
@@ -8,6 +9,16 @@ from app.main import app
 
 
 class SmokeTest(unittest.TestCase):
+    def test_docs_live_validation_checklist_links(self):
+        repo_root = Path(__file__).resolve().parents[1]
+        readme = (repo_root / 'README.md').read_text(encoding='utf-8')
+        runbook = (repo_root / 'docs/ops/kis-quote-runbook.md').read_text(encoding='utf-8')
+        checklist_path = repo_root / 'docs/ops/kis-order-live-validation-checklist.md'
+
+        self.assertTrue(checklist_path.exists())
+        self.assertIn('kis-order-live-validation-checklist.md', readme)
+        self.assertIn('kis-order-live-validation-checklist.md', runbook)
+
     def test_quotes_order_modify_cancel_and_portfolio(self):
         c = TestClient(app)
 
@@ -42,10 +53,10 @@ class SmokeTest(unittest.TestCase):
         # portfolio endpoints contract
         balances = c.get('/v1/balances', params={'account_id': 'A1'})
         positions = c.get('/v1/positions', params={'account_id': 'A1'})
-        self.assertEqual(balances.status_code, 200)
-        self.assertEqual(positions.status_code, 200)
-        self.assertIsInstance(balances.json(), list)
-        self.assertIsInstance(positions.json(), list)
+        self.assertEqual(balances.status_code, 503)
+        self.assertEqual(positions.status_code, 503)
+        self.assertEqual(balances.json(), {'detail': 'PORTFOLIO_PROVIDER_NOT_CONFIGURED'})
+        self.assertEqual(positions.json(), {'detail': 'PORTFOLIO_PROVIDER_NOT_CONFIGURED'})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add live order validation checklist doc with read-only and approved-order phases
- link checklist from README and quote runbook
- update runbook portfolio misconfiguration behavior to 503 signal
- add smoke test ensuring checklist references exist and smoke flow matches current portfolio endpoint behavior

## Verification
- python3 -m unittest tests.test_smoke -v
