### PR TITLE
feat(risk): derive sell qty from position provider

### DIFF
--- a/app/services/risk_policy.py
+++ b/app/services/risk_policy.py
@@ -22,6 +22,8 @@ def evaluate_side_policy(
 
     if req.side == 'SELL':
         available_qty = get_available_sell_qty(req.account_id, req.symbol)
+        if available_qty is None:
+            return {'ok': False, 'reason': 'POSITION_PROVIDER_UNAVAILABLE'}
         if req.qty > available_qty:
             return {'ok': False, 'reason': 'INSUFFICIENT_POSITION_QTY'}
         return {'ok': True, 'reason': None}

--- a/tests/test_risk_policy.py
+++ b/tests/test_risk_policy.py
@@ -19,6 +19,14 @@ class RiskPolicyTest(unittest.TestCase):
         )
         self.assertEqual(result, {'ok': False, 'reason': 'INSUFFICIENT_POSITION_QTY'})
 
+
+    def test_sell_returns_provider_unavailable_when_qty_lookup_missing(self):
+        result = evaluate_side_policy(
+            RiskCheckRequest(account_id='A1', symbol='005930', side='SELL', qty=1, price=70000),
+            get_available_sell_qty=lambda _a, _s: None,
+        )
+        self.assertEqual(result, {'ok': False, 'reason': 'POSITION_PROVIDER_UNAVAILABLE'})
+
     def test_sell_notional_limit_not_applied(self):
         result = evaluate_side_policy(
             RiskCheckRequest(account_id='A1', symbol='005930', side='SELL', qty=200, price=70000),


### PR DESCRIPTION
## Summary
- wire SELL risk quantity lookup to provider path via `quote_gateway_service.rest_client.get_positions` when available
- return explicit `POSITION_PROVIDER_UNAVAILABLE` reason for SELL when provider is not configured
- keep BUY path and existing risk contracts unchanged
- add/update SELL risk policy and route tests for provider-backed qty resolution

## Verification
- `python3 -m unittest tests.test_risk_policy tests.test_mvp_iteration1 -v`
- Result: **OK (33 tests)**