### PR TITLE
feat(ops): add live readiness preflight endpoint

### DIFF
--- a/app/schemas/session.py
+++ b/app/schemas/session.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel
+
+
+class LiveReadinessResponse(BaseModel):
+    required_env_missing: list[str]
+    ws_connected: bool
+    ws_last_error: str | None = None
+    can_trade: bool
+    blocker_reasons: list[str]


### PR DESCRIPTION
## Summary
- add `/v1/session/live-readiness` preflight endpoint for live trading readiness
- include readiness payload fields: `required_env_missing`, `ws_connected`, `ws_last_error`, `can_trade`, `blocker_reasons`
- set `can_trade=false` when required env is missing or websocket is disconnected/has error
- add/update MVP + smoke tests for endpoint behavior and contract

## Verification
- `python3 -m unittest tests.test_mvp_iteration1 tests.test_smoke -v`
