### PR TITLE
docs(api): add redoc static site skeleton for pages

### DIFF
--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>KIS Gateway API Docs</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <main>
+      <h1>KIS Gateway API 문서</h1>
+      <p>컨슈머 개발을 위한 정적 API 문서 진입점입니다.</p>
+      <ul>
+        <li><a href="./redoc-live.html">Live API (openapi-live.json)</a></li>
+        <li><a href="./redoc-next.html">Next API Contract (openapi-next.yaml)</a></li>
+      </ul>
+      <p>
+        스펙 원본 링크:
+        <a href="./api/openapi-live.json">openapi-live.json</a>,
+        <a href="./api/openapi-next.yaml">openapi-next.yaml</a>
+      </p>
+    </main>
+  </body>
+</html>

--- a/docs/site/redoc-live.html
+++ b/docs/site/redoc-live.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>KIS Gateway API Docs - Live</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <redoc spec-url="./api/openapi-live.json"></redoc>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>
+  </body>
+</html>

--- a/docs/site/redoc-next.html
+++ b/docs/site/redoc-next.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>KIS Gateway API Docs - Next</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <redoc spec-url="./api/openapi-next.yaml"></redoc>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>
+  </body>
+</html>

--- a/docs/site/styles.css
+++ b/docs/site/styles.css
@@ -1,0 +1,29 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  line-height: 1.5;
+  color: #111827;
+  background: #f9fafb;
+}
+
+main {
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 48px 20px;
+}
+
+h1 {
+  margin-top: 0;
+}
+
+ul {
+  padding-left: 20px;
+}
+
+a {
+  color: #1d4ed8;
+}

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -12,6 +12,21 @@ class SmokeTest(unittest.TestCase):
     def setUp(self):
         app.state.quote_gateway_service.rest_client = _DemoRestQuoteClient()
 
+    def test_api_docs_site_skeleton_links(self):
+        repo_root = Path(__file__).resolve().parents[1]
+        index_html = (repo_root / 'docs/site/index.html').read_text(encoding='utf-8')
+        redoc_live = (repo_root / 'docs/site/redoc-live.html').read_text(encoding='utf-8')
+        redoc_next = (repo_root / 'docs/site/redoc-next.html').read_text(encoding='utf-8')
+        styles = repo_root / 'docs/site/styles.css'
+
+        self.assertTrue(styles.exists())
+        self.assertIn('redoc-live.html', index_html)
+        self.assertIn('redoc-next.html', index_html)
+        self.assertIn('./api/openapi-live.json', index_html)
+        self.assertIn('./api/openapi-next.yaml', index_html)
+        self.assertIn('./api/openapi-live.json', redoc_live)
+        self.assertIn('./api/openapi-next.yaml', redoc_next)
+
     def test_docs_live_validation_checklist_links(self):
         repo_root = Path(__file__).resolve().parents[1]
         readme = (repo_root / 'README.md').read_text(encoding='utf-8')


### PR DESCRIPTION
## Summary
- add static docs site skeleton for GitHub Pages + Redoc
- add index hub and two Redoc entry pages (live/next)
- add smoke test asserting site files and key spec links

## Verification
- python3 -m unittest tests.test_smoke -v
