### PR TITLE
ci(docs): auto-deploy redoc api docs to github pages on main

### DIFF
--- a/.github/workflows/api-docs-pages.yml
+++ b/.github/workflows/api-docs-pages.yml
@@ -1,0 +1,42 @@
+name: api-docs-pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install project
+        run: pip install -e .
+
+      - name: Build API docs site artifacts
+        run: python3 scripts/build_api_docs_site.py
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ curl -s http://127.0.0.1:8890/v1/metrics/quote | jq
 상세 운영 절차: `docs/ops/kis-quote-runbook.md`
 주문 실검증 체크리스트: `docs/ops/kis-order-live-validation-checklist.md`
 
+## API Docs (GitHub Pages)
+- Pages: `https://rbitts.github.io/kis-trading-gateway-repo/`
+- Redoc Live: `https://rbitts.github.io/kis-trading-gateway-repo/redoc-live.html`
+- Redoc Next: `https://rbitts.github.io/kis-trading-gateway-repo/redoc-next.html`
+- Raw specs: `./docs/site/api/openapi-live.json`, `./docs/site/api/openapi-next.yaml`
+
 ## Quick API Check
 ```bash
 # session state

--- a/docs/ops/order-api-contract.md
+++ b/docs/ops/order-api-contract.md
@@ -27,6 +27,11 @@
 }
 ```
 
+## Public API Docs (GitHub Pages)
+- Hub: `https://rbitts.github.io/kis-trading-gateway-repo/`
+- Redoc Live: `https://rbitts.github.io/kis-trading-gateway-repo/redoc-live.html`
+- Redoc Next: `https://rbitts.github.io/kis-trading-gateway-repo/redoc-next.html`
+
 ## Next Contract Endpoints (OpenAPI Draft)
 - `POST /v1/orders/{order_id}/cancel` (`operationId: cancelOrder`)
 - `POST /v1/orders/{order_id}/modify` (`operationId: modifyOrder`)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -37,6 +37,21 @@ class SmokeTest(unittest.TestCase):
         self.assertTrue(live.exists())
         self.assertTrue(next_yaml.exists())
 
+    def test_api_docs_pages_workflow_and_readme_references(self):
+        repo_root = Path(__file__).resolve().parents[1]
+        workflow = (repo_root / '.github/workflows/api-docs-pages.yml').read_text(encoding='utf-8')
+        readme = (repo_root / 'README.md').read_text(encoding='utf-8')
+
+        self.assertIn('branches:', workflow)
+        self.assertIn('- main', workflow)
+        self.assertIn('upload-pages-artifact', workflow)
+        self.assertIn('path: docs/site', workflow)
+        self.assertIn('api-docs-pages', workflow)
+
+        self.assertIn('https://rbitts.github.io/kis-trading-gateway-repo/', readme)
+        self.assertIn('redoc-live.html', readme)
+        self.assertIn('redoc-next.html', readme)
+
     def test_docs_live_validation_checklist_links(self):
         repo_root = Path(__file__).resolve().parents[1]
         readme = (repo_root / 'README.md').read_text(encoding='utf-8')


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to auto-deploy API docs site to GitHub Pages on main push
- document public Pages/Redoc links in README and order API contract doc
- add smoke checks for workflow trigger/artifact path and README links

## Verification
- python3 -m unittest tests.test_smoke -v
