### PR TITLE
chore: finalize api docs pages verification

### DIFF
--- a/docs/evidence/2026-02-28-api-docs-pages-verification.md
+++ b/docs/evidence/2026-02-28-api-docs-pages-verification.md
@@ -1,0 +1,29 @@
+# API Docs Pages Verification (Task 4)
+
+## Targeted checks
+Command:
+`python3 scripts/build_api_docs_site.py`
+
+Result:
+- build script completed
+- generated/updated:
+  - `docs/site/api/openapi-live.json`
+  - `docs/site/api/openapi-next.yaml`
+
+Command:
+`python3 -m unittest tests.test_smoke -v`
+
+Result:
+- Ran 6 tests
+- All PASS (OK)
+
+## Full regression
+Command:
+`python3 -m unittest discover -s tests -v`
+
+Result:
+- Ran 115 tests
+- All PASS (OK)
+
+## Verdict
+PASS


### PR DESCRIPTION
## Summary
- finalize API docs pages cycle verification evidence
- record targeted docs-build/smoke results and full regression output

## Verification
- python3 scripts/build_api_docs_site.py
- python3 -m unittest tests.test_smoke -v
- python3 -m unittest discover -s tests -v
