### PR TITLE
docs(api): add multi-language integration examples

### DIFF
--- a/docs/api/consumer-api-guide.md
+++ b/docs/api/consumer-api-guide.md
@@ -16,8 +16,121 @@
 - `Content-Type: application/json`
 - `Idempotency-Key` (주문 생성 시 필수)
 
-## 3) First Flow Preview
-- Quotes → Orders → Order Status
+## 3) Common Flows
+
+### 3.1 Quote 조회
+```bash
+curl -s "http://127.0.0.1:8890/v1/quotes/005930" | jq
+```
+
+```python
+import requests
+res = requests.get("http://127.0.0.1:8890/v1/quotes/005930", timeout=5)
+print(res.json())
+```
+
+```javascript
+const res = await fetch("http://127.0.0.1:8890/v1/quotes/005930");
+console.log(await res.json());
+```
+
+### 3.2 Order Create + Status
+```bash
+ORDER_ID=$(curl -s -X POST http://127.0.0.1:8890/v1/orders \
+  -H 'Content-Type: application/json' \
+  -H 'Idempotency-Key: consumer-buy-1' \
+  -d '{"account_id":"A1","symbol":"005930","side":"BUY","qty":1,"price":70000,"order_type":"LIMIT"}' | jq -r '.order_id')
+
+curl -s "http://127.0.0.1:8890/v1/orders/${ORDER_ID}" | jq
+```
+
+```python
+import requests
+base = "http://127.0.0.1:8890/v1"
+order = requests.post(
+    f"{base}/orders",
+    headers={"Idempotency-Key": "consumer-buy-1"},
+    json={
+        "account_id": "A1",
+        "symbol": "005930",
+        "side": "BUY",
+        "qty": 1,
+        "price": 70000,
+        "order_type": "LIMIT",
+    },
+    timeout=5,
+).json()
+print(requests.get(f"{base}/orders/{order['order_id']}", timeout=5).json())
+```
+
+```javascript
+const base = "http://127.0.0.1:8890/v1";
+const createRes = await fetch(`${base}/orders`, {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "Idempotency-Key": "consumer-buy-1",
+  },
+  body: JSON.stringify({
+    account_id: "A1",
+    symbol: "005930",
+    side: "BUY",
+    qty: 1,
+    price: 70000,
+    order_type: "LIMIT",
+  }),
+});
+const created = await createRes.json();
+const statusRes = await fetch(`${base}/orders/${created.order_id}`);
+console.log(await statusRes.json());
+```
+
+### 3.3 Modify / Cancel
+```bash
+curl -s -X POST "http://127.0.0.1:8890/v1/orders/${ORDER_ID}/modify" \
+  -H 'Content-Type: application/json' \
+  -d '{"qty":2,"price":70100}' | jq
+
+curl -s -X POST "http://127.0.0.1:8890/v1/orders/${ORDER_ID}/cancel" | jq
+```
+
+```python
+requests.post(f"{base}/orders/{order['order_id']}/modify", json={"qty": 2, "price": 70100}, timeout=5)
+requests.post(f"{base}/orders/{order['order_id']}/cancel", timeout=5)
+```
+
+```javascript
+await fetch(`${base}/orders/${created.order_id}/modify`, {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ qty: 2, price: 70100 }),
+});
+await fetch(`${base}/orders/${created.order_id}/cancel`, { method: "POST" });
+```
+
+### 3.4 Risk Check
+```bash
+curl -s -X POST "http://127.0.0.1:8890/v1/risk/check" \
+  -H 'Content-Type: application/json' \
+  -d '{"account_id":"A1","symbol":"005930","side":"BUY","qty":1,"price":70000}' | jq
+```
+
+```python
+print(requests.post(
+    f"{base}/risk/check",
+    json={"account_id": "A1", "symbol": "005930", "side": "BUY", "qty": 1, "price": 70000},
+    timeout=5,
+).json())
+```
+
+```javascript
+const risk = await fetch(`${base}/risk/check`, {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ account_id: "A1", symbol: "005930", side: "BUY", qty: 1, price: 70000 }),
+});
+console.log(await risk.json());
+```
 
 ## 4) Reference (Appendix)
 - 상세 엔드포인트/에러/운영 체크는 아래 부록 섹션에서 확장 예정

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -46,6 +46,13 @@ class SmokeTest(unittest.TestCase):
         self.assertIn('Quick Start', guide)
         self.assertIn('Base URL', guide)
         self.assertIn('Auth / Headers', guide)
+        self.assertIn('```bash', guide)
+        self.assertIn('```python', guide)
+        self.assertIn('```javascript', guide)
+        self.assertIn('Quote 조회', guide)
+        self.assertIn('Order Create + Status', guide)
+        self.assertIn('Modify / Cancel', guide)
+        self.assertIn('Risk Check', guide)
 
     def test_docs_live_validation_checklist_links(self):
         repo_root = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Summary
- enrich consumer markdown guide with common integration flows
- add cURL, Python, JavaScript examples for quote/order/status/modify-cancel/risk-check
- extend smoke checks for multi-language snippets and scenario sections

## Verification
- python3 -m unittest tests.test_smoke -v
