### PR TITLE
fix(ci): add requests dependency for docs pages build

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ curl -s http://127.0.0.1:8890/v1/metrics/quote | jq
 
 ## API Docs
 - Consumer Markdown Guide: `docs/api/consumer-api-guide.md`
+- Redoc (Live): `https://rbitts.github.io/kis-trading-gateway-repo/redoc-live.html`
+- Redoc (Next): `https://rbitts.github.io/kis-trading-gateway-repo/redoc-next.html`
 - Raw specs: `./docs/site/api/openapi-live.json`, `./docs/site/api/openapi-next.yaml`
 
 ## Quick API Check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,8 @@ requires-python = ">=3.10"
 dependencies = [
   "fastapi>=0.115.0",
   "uvicorn>=0.30.0",
-  "pydantic>=2.7.0"
+  "pydantic>=2.7.0",
+  "requests>=2.31.0"
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary
- make Pages docs build stable by adding missing `requests` runtime dependency used by `app.main` import path
- keep both docs paths visible in README: consumer markdown + Redoc pages

## Verification
- python3 -m unittest tests.test_smoke -v
