### PR TITLE
feat: add symbol_name to KIS quote contract

### DIFF
--- a/app/integrations/kis_rest.py
+++ b/app/integrations/kis_rest.py
@@ -140,8 +140,16 @@ class KisRestClient:
         payload = response.json()
         output = payload.get("output", {})
 
+        symbol_name = str(
+            output.get("hts_kor_isnm")
+            or output.get("prdt_name")
+            or output.get("bstp_kor_isnm")
+            or ""
+        ).strip() or None
+
         return {
             "symbol": symbol,
+            "symbol_name": symbol_name,
             "price": self._to_float(output.get("stck_prpr")),
             "change_pct": self._to_float(output.get("prdy_ctrt")),
             "turnover": self._to_float(output.get("acml_tr_pbmn")),

--- a/app/schemas/quote.py
+++ b/app/schemas/quote.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel
 
 class QuoteSnapshot(BaseModel):
     symbol: str
+    symbol_name: str | None = None
     price: float
     change_pct: float
     turnover: float

--- a/app/services/quote_cache.py
+++ b/app/services/quote_cache.py
@@ -53,6 +53,7 @@ class QuoteIngestWorker:
         now = int(time.time())
         snapshot = QuoteSnapshot(
             symbol=payload["symbol"],
+            symbol_name=str(payload.get("symbol_name") or "").strip() or None,
             price=float(payload["price"]),
             change_pct=float(payload.get("change_pct", 0.0)),
             turnover=float(payload.get("turnover", 0.0)),
@@ -137,6 +138,7 @@ def seed_demo_quote(symbol: str) -> None:
     quote_cache.upsert(
         QuoteSnapshot(
             symbol=symbol,
+            symbol_name=None,
             price=70000.0,
             change_pct=0.0,
             turnover=0.0,

--- a/app/services/quote_gateway.py
+++ b/app/services/quote_gateway.py
@@ -70,6 +70,7 @@ class QuoteGatewayService:
             raise
         return QuoteSnapshot(
             symbol=str(payload["symbol"]),
+            symbol_name=str(payload.get("symbol_name") or "").strip() or None,
             price=float(payload["price"]),
             change_pct=float(payload.get("change_pct", 0.0)),
             turnover=float(payload.get("turnover", 0.0)),

--- a/tests/test_kis_rest_client.py
+++ b/tests/test_kis_rest_client.py
@@ -53,6 +53,7 @@ class TestKisRestClient(unittest.TestCase):
                 "stck_prpr": "71200",
                 "prdy_ctrt": "1.35",
                 "acml_tr_pbmn": "123456789",
+                "hts_kor_isnm": "삼성전자",
             }
         }
         quote_response.raise_for_status.return_value = None
@@ -71,6 +72,7 @@ class TestKisRestClient(unittest.TestCase):
         quote = client.get_quote("005930")
 
         self.assertEqual(quote["symbol"], "005930")
+        self.assertEqual(quote["symbol_name"], "삼성전자")
         self.assertEqual(quote["price"], 71200.0)
         self.assertEqual(quote["change_pct"], 1.35)
         self.assertEqual(quote["turnover"], 123456789.0)


### PR DESCRIPTION
## Summary
- QuoteSnapshot 스키마에 `symbol_name` optional 필드 추가
- KIS REST quote 파싱 시 `hts_kor_isnm/prdt_name` 우선으로 종목명 채움
- quote gateway/WS ingest 경로에서 `symbol_name` 보존

## Verification
- `python3 -m pytest -q tests/test_kis_rest_client.py tests/test_quote_gateway_service.py`

## Remaining Risks
- KIS 응답 포맷 변경 시 `symbol_name` 추출 키(`hts_kor_isnm`, `prdt_name`, `bstp_kor_isnm`) 누락 가능
- WS 실시간 페이로드는 종목명을 항상 포함하지 않으므로 REST/사전 매핑과의 결합이 여전히 필요
