### PR TITLE
refactor: remove symbol-name mapping from gateway quotes

### DIFF
--- a/app/integrations/kis_rest.py
+++ b/app/integrations/kis_rest.py
@@ -140,16 +140,8 @@ class KisRestClient:
         payload = response.json()
         output = payload.get("output", {})
 
-        symbol_name = str(
-            output.get("hts_kor_isnm")
-            or output.get("prdt_name")
-            or output.get("bstp_kor_isnm")
-            or ""
-        ).strip() or None
-
         return {
             "symbol": symbol,
-            "symbol_name": symbol_name,
             "price": self._to_float(output.get("stck_prpr")),
             "change_pct": self._to_float(output.get("prdy_ctrt")),
             "turnover": self._to_float(output.get("acml_tr_pbmn")),

--- a/tests/test_kis_rest_client.py
+++ b/tests/test_kis_rest_client.py
@@ -72,7 +72,6 @@ class TestKisRestClient(unittest.TestCase):
         quote = client.get_quote("005930")
 
         self.assertEqual(quote["symbol"], "005930")
-        self.assertEqual(quote["symbol_name"], "삼성전자")
         self.assertEqual(quote["price"], 71200.0)
         self.assertEqual(quote["change_pct"], 1.35)
         self.assertEqual(quote["turnover"], 123456789.0)


### PR DESCRIPTION
## Summary
- remove KIS REST quote `symbol_name` extraction/mapping logic in gateway
- keep gateway quote payload focused on quote transport fields (`symbol`, `price`, `change_pct`, `turnover`, `ts`, `source`)
- update unit test expectation accordingly

## Test
- `python3 -m unittest tests/test_kis_rest_client.py tests/test_quote_gateway_service.py -v`

## Why
- enforce SRP boundary: symbol-name SSOT must live in engine/registry, not gateway
