### PR TITLE
fix: off-hours batch REST fallback for partial WS quotes

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -152,13 +152,8 @@ def get_quote(symbol: str, request: Request):
 def get_quotes(symbols: str, request: Request):
     service = request.app.state.quote_gateway_service
     req = [s.strip() for s in symbols.split(',') if s.strip()]
-    out = []
-    for s in req:
-        try:
-            out.append(service.get_quote(s).model_dump())
-        except RestRateLimitCooldownError as exc:
-            raise HTTPException(status_code=503, detail='REST_RATE_LIMIT_COOLDOWN') from exc
-    return out
+    out = service.get_quotes(req)
+    return [row.model_dump() for row in out]
 
 
 @router.post('/risk/check')


### PR DESCRIPTION
## Summary
- Add batch quote resolution path in gateway (`QuoteGatewayService.get_quotes`) to stabilize off-hours responses when WS data is partial.
- Keep fresh WS quotes first, then fill missing symbols via REST fallback in-symbol-batch flow.
- Add operational metrics/logs for fallback visibility:
  - `fallback_triggered`
  - `rest_filled_count`
  - `ws_count`
  - `batch_target_count`, `batch_final_count`, `batch_market_open`
- Wire `/v1/quotes` route to use batch resolver (instead of per-symbol hard-fail loop).
- Add tests for off-hours partial WS + REST fill and timeout resilience.

## Root cause
- During off-hours, engine requests topN=6 symbols but gateway often had only 2~3 valid WS cache entries.
- Existing `/quotes` path processed symbol-by-symbol and could shrink usable set when stale/failed symbols were not consistently REST-filled.
- Result: engine saw `final_count` below `top_n` and emitted `partial_data` degradations.

## Risk / Impact
1. **REST pressure increase**: batch fallback can increase REST calls off-hours when WS cache coverage is low.
2. **Partial output on repeated REST failures**: timeout/429 conditions can still lead to partial set (but now no full-request crash).
3. **Metric semantics changed**: `fallback_triggered` counts batch-trigger events (not per-symbol), monitor dashboards accordingly.

## Validation
- `python3 -m pytest -q tests/test_quote_gateway_service.py tests/test_quote_metrics_extended.py tests/test_runtime_portfolio_binding.py`
- `python3 -m pytest -q`

## Rollout
- Merge gateway first, then restart chain: kis-gateway -> engine -> dashboard.
- Confirm `/api/engine/universe` final_count near/equals top_n=6 and degraded reasons show reduced `partial_data`.
