### PR TITLE
Stabilize off-hours quote batch with retry/cooldown/jitter

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -152,8 +152,20 @@ def get_quote(symbol: str, request: Request):
 def get_quotes(symbols: str, request: Request):
     service = request.app.state.quote_gateway_service
     req = [s.strip() for s in symbols.split(',') if s.strip()]
-    out = service.get_quotes(req)
-    return [row.model_dump() for row in out]
+    out, meta = service.get_quotes(req)
+    rows = [row.model_dump() for row in out]
+    if meta.missing_count > 0:
+        return {
+            'quotes': rows,
+            'partial': True,
+            'meta': {
+                'target_count': meta.target_count,
+                'final_count': meta.final_count,
+                'missing_count': meta.missing_count,
+                'failed_symbols': meta.failed_symbols,
+            },
+        }
+    return rows
 
 
 @router.post('/risk/check')


### PR DESCRIPTION
## Summary
- stabilize `/v1/quotes` batch resolution for off-hours REST fallback path
- add per-symbol jitter delay (configurable min/max) to avoid burst 500s
- add per-symbol retry with exponential backoff and cooldown after repeated failures
- reuse last-good cached quote during cooldown/failure before dropping symbol
- include partial response metadata (`failed_symbols`, `missing_count`) when final batch is incomplete

## Changes
- `QuoteGatewayService`
  - retries REST quote fetch per symbol (`rest_retry_attempts`, `rest_backoff_base_sec`)
  - introduces symbol-level jitter between batch requests (`symbol_delay_min_sec`, `symbol_delay_max_sec`)
  - marks cooldown on repeated failures and falls back to last-good cache
  - exposes batch failure/missing metrics
  - returns `(quotes, meta)` from `get_quotes`
- `/v1/quotes`
  - returns legacy list when complete
  - returns `{ quotes, partial, meta }` when partial
- tests
  - add retry success and cooldown+last-good reuse scenarios
  - add API partial metadata response verification

## Verification
```bash
python3 -m pytest -q tests/test_quote_gateway_service.py tests/test_mvp_iteration1.py
# 42 passed
```
