### PR TITLE
Fix WS-path latency regression: jitter only on REST attempts

### DIFF
--- a/app/services/quote_gateway.py
+++ b/app/services/quote_gateway.py
@@ -199,10 +199,8 @@ class QuoteGatewayService:
 
         out: list[QuoteSnapshot] = []
         failed_symbols: list[str] = []
-        for idx, symbol in enumerate(unique_symbols):
-            if idx > 0:
-                self._sleep_with_jitter()
-
+        rest_attempt_index = 0
+        for symbol in unique_symbols:
             if symbol in ws_rows:
                 out.append(ws_rows[symbol])
                 continue
@@ -216,6 +214,9 @@ class QuoteGatewayService:
                 continue
 
             try:
+                if rest_attempt_index > 0:
+                    self._sleep_with_jitter()
+                rest_attempt_index += 1
                 quote = self._fetch_rest(symbol, now)
                 out.append(quote)
                 rest_filled_count += 1


### PR DESCRIPTION
## Summary
- fix latency regression from PR #83 review: jitter sleep is now applied only before REST attempts
- WS-hit symbols no longer incur artificial delay
- add regression test to ensure WS-only batch does not call jitter sleep

## Changes
- `app/services/quote_gateway.py`
  - remove unconditional per-symbol jitter in batch loop
  - apply jitter only right before REST fallback call
- `tests/test_quote_gateway_service.py`
  - add `test_ws_only_batch_does_not_apply_jitter_sleep`

## Verification
```bash
python3 -m pytest -q tests/test_quote_gateway_service.py tests/test_mvp_iteration1.py
# 43 passed
```
