### PR TITLE
fix: accept wrapped/bytes WS payload variants

### DIFF
--- a/app/integrations/kis_ws.py
+++ b/app/integrations/kis_ws.py
@@ -24,10 +24,25 @@ def _to_float_default(value: Any, default: float = 0.0) -> float:
         return default
 
 
-def parse_message(payload: dict | str) -> Dict[str, Any]:
-    """Parse raw KIS WS payload into quote snapshot-compatible dict."""
-    raw: Dict[str, Any]
+def _payload_hint(payload: Any) -> str:
+    if isinstance(payload, dict):
+        keys = list(payload.keys())[:5]
+        return f"type=dict keys={keys}"
+    if isinstance(payload, str):
+        return f"type=str len={len(payload)}"
+    if isinstance(payload, (bytes, bytearray)):
+        return f"type={type(payload).__name__} len={len(payload)}"
+    return f"type={type(payload).__name__}"
 
+
+def _decode_payload_to_dict(payload: Any) -> Dict[str, Any]:
+    if isinstance(payload, dict):
+        return payload
+    if isinstance(payload, (bytes, bytearray)):
+        try:
+            payload = payload.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ValueError("payload bytes must be utf-8 encoded") from exc
     if isinstance(payload, str):
         try:
             decoded = json.loads(payload)
@@ -35,11 +50,22 @@ def parse_message(payload: dict | str) -> Dict[str, Any]:
             raise ValueError("payload must be valid JSON string or dict") from exc
         if not isinstance(decoded, dict):
             raise ValueError("decoded payload must be an object")
-        raw = decoded
-    elif isinstance(payload, dict):
-        raw = payload
-    else:
-        raise ValueError("payload must be dict or JSON string")
+        return decoded
+    raise ValueError("payload must be dict, JSON string, or utf-8 JSON bytes")
+
+
+def parse_message(payload: dict | str | bytes | bytearray) -> Dict[str, Any]:
+    """Parse raw KIS WS payload into quote snapshot-compatible dict."""
+    raw = _decode_payload_to_dict(payload)
+
+    for key in ("payload", "data", "message"):
+        nested = raw.get(key) if isinstance(raw, dict) else None
+        if isinstance(nested, dict):
+            raw = nested
+            break
+        if isinstance(nested, (str, bytes, bytearray)):
+            raw = _decode_payload_to_dict(nested)
+            break
 
     body = raw.get("body")
     nested_output = body.get("output") if isinstance(body, dict) else None
@@ -186,7 +212,7 @@ class KisWsClient:
             },
         }
 
-    def handle_raw_message(self, payload: dict | str) -> Dict[str, Any]:
+    def handle_raw_message(self, payload: dict | str | bytes | bytearray) -> Dict[str, Any]:
         quote = parse_message(payload)
         if self._on_message is not None:
             self._on_message(quote)
@@ -214,7 +240,7 @@ class KisWsClient:
                 self.handle_raw_message(raw_message)
             except ValueError as exc:
                 # KIS ACK/heartbeat/control messages may not include quote fields.
-                print(f"[WS][ws_message_skip] reason={exc}", flush=True)
+                print(f"[WS][ws_message_skip] reason={exc} hint={_payload_hint(raw_message)}", flush=True)
 
         def _on_error(_: Any, error: Any) -> None:
             self.last_error = str(error)

--- a/tests/test_kis_ws_live_client.py
+++ b/tests/test_kis_ws_live_client.py
@@ -60,6 +60,27 @@ class _FakeWebSocketAppWithAck(_FakeWebSocketApp):
             )
 
 
+class _FakeWebSocketAppWithWrappedBytesAndInvalid(_FakeWebSocketApp):
+    def run_forever(self):
+        if self.on_open is not None:
+            self.on_open(self)
+        if self.on_message is not None:
+            wrapped = {
+                "payload": {
+                    "body": {
+                        "output": {
+                            "mksc_shrn_iscd": "005930",
+                            "stck_prpr": "71300",
+                            "prdy_ctrt": "1.49",
+                            "acml_tr_pbmn": "2233445566",
+                        }
+                    }
+                }
+            }
+            self.on_message(self, json.dumps(wrapped).encode("utf-8"))
+            self.on_message(self, b"not-json")
+
+
 class TestKisWsLiveClient(unittest.TestCase):
     def test_connect_subscribe_and_ingest_callback_flow(self):
         approval_client = MagicMock()
@@ -106,6 +127,23 @@ class TestKisWsLiveClient(unittest.TestCase):
         client.connect_and_subscribe(symbols=["005930"], run_forever=True)
         self.assertEqual(len(received), 1)
         self.assertEqual(received[0]["symbol"], "005930")
+
+    def test_wrapped_bytes_payload_is_accepted_and_invalid_bytes_skipped(self):
+        approval_client = MagicMock()
+        approval_client.issue_approval_key.return_value = "approval-123"
+
+        received = []
+        client = KisWsClient(
+            on_message=lambda quote: received.append(quote),
+            approval_key_client=approval_client,
+            env="mock",
+            websocket_app_factory=_FakeWebSocketAppWithWrappedBytesAndInvalid,
+        )
+
+        client.connect_and_subscribe(symbols=["005930"], run_forever=True)
+        self.assertEqual(len(received), 1)
+        self.assertEqual(received[0]["symbol"], "005930")
+        self.assertEqual(received[0]["price"], 71300.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- accept WS payload as dict/string/bytes (utf-8 JSON)
- support wrapped envelope keys (`payload`, `data`, `message`) before normalization
- keep strict invalid-payload skip behavior
- improve skip logs with compact payload hint (type/len/keys)
- add test for wrapped bytes payload acceptance and invalid bytes skip path

## Verification
- `python3 -m unittest tests/test_kis_ws_live_client.py -v`
- `python3 -m unittest tests/test_kis_ws_reconnect.py -v`

Closes #85
