### PR TITLE
fix: harden H0STCNT0 parser with indexed 46-field records

### DIFF
--- a/app/integrations/kis_ws.py
+++ b/app/integrations/kis_ws.py
@@ -39,47 +39,65 @@ def _payload_hint(payload: Any) -> str:
 def _decode_pipe_realtime_payload(payload: str) -> Dict[str, Any] | None:
     # KIS realtime frames may arrive as delimited text:
     #   0|H0STCNT0|001|<field0^field1^...>
-    # We only extract the minimal fields needed for quote cache.
+    # H0STCNT0 has fixed-width records (46 fields each).
     if "|" not in payload or "^" not in payload:
         return None
     parts = payload.split("|", 3)
     if len(parts) < 4:
         return None
+
     tr_id = parts[1].strip()
     if tr_id != "H0STCNT0":
         return None
+
+    try:
+        data_cnt = int(parts[2].strip())
+    except (TypeError, ValueError):
+        return None
+    if data_cnt <= 0:
+        return None
+
     body = parts[3]
     fields = [f.strip() for f in body.split("^")]
-    if not fields:
+    chunk_size = 46
+    expected_count = data_cnt * chunk_size
+    if len(fields) != expected_count:
         return None
 
-    symbol = next((f for f in fields if re.fullmatch(r"\d{6}", f)), None)
-    if not symbol:
-        return None
+    for idx in range(data_cnt):
+        chunk = fields[idx * chunk_size : (idx + 1) * chunk_size]
+        if len(chunk) != chunk_size:
+            return None
 
-    # pick the first plausible price after symbol
-    try:
-        start_idx = fields.index(symbol) + 1
-    except ValueError:
-        start_idx = 0
-    price = None
-    for f in fields[start_idx:]:
-        if re.fullmatch(r"-?\d+(?:\.\d+)?", f):
-            try:
-                val = float(f)
-            except ValueError:
-                continue
-            if val > 0:
-                price = val
-                break
-    if price is None:
-        return None
+        symbol = chunk[0]
+        price_raw = chunk[2]
+        if not re.fullmatch(r"\d{6}", symbol):
+            continue
+        try:
+            price = float(price_raw)
+        except (TypeError, ValueError):
+            continue
+        if price <= 0:
+            continue
 
-    return {
-        "symbol": symbol,
-        "price": price,
-        "source": "kis-ws",
-    }
+        quote: Dict[str, Any] = {
+            "symbol": symbol,
+            "price": price,
+            "source": "kis-ws",
+        }
+
+        trade_time = chunk[1]
+        if trade_time:
+            quote["trade_time"] = trade_time
+
+        change_pct = _to_float_default(chunk[5], default=0.0)
+        turnover = _to_float_default(chunk[14], default=0.0)
+        quote["change_pct"] = change_pct
+        quote["turnover"] = turnover
+
+        return quote
+
+    return None
 
 
 def _decode_payload_to_dict(payload: Any) -> Dict[str, Any]:

--- a/tests/test_kis_ws_parser.py
+++ b/tests/test_kis_ws_parser.py
@@ -75,14 +75,51 @@ class TestKisWsParser(unittest.TestCase):
         self.assertEqual(message["body"]["input"]["tr_id"], "H0STCNT0")
         self.assertEqual(message["body"]["input"]["tr_key"], "005930")
 
-    def test_parse_message_supports_pipe_realtime_frame(self):
-        payload = "0|H0STCNT0|001|005930^71300^1.49^2233445566"
+    def _build_h0stcnt0_record(
+        self,
+        *,
+        symbol: str,
+        trade_time: str = "093001",
+        price: str = "71300",
+        change_pct: str = "1.49",
+        turnover: str = "2233445566",
+    ) -> list[str]:
+        fields = ["" for _ in range(46)]
+        fields[0] = symbol
+        fields[1] = trade_time
+        fields[2] = price
+        fields[5] = change_pct
+        fields[14] = turnover
+        return fields
+
+    def test_parse_message_pipe_realtime_uses_fixed_price_index_even_with_trade_time(self):
+        record = self._build_h0stcnt0_record(symbol="005930", trade_time="093001", price="71300")
+        payload = "0|H0STCNT0|001|" + "^".join(record)
 
         parsed = parse_message(payload)
 
         self.assertEqual(parsed["symbol"], "005930")
         self.assertEqual(parsed["price"], 71300.0)
+        self.assertEqual(parsed["change_pct"], 1.49)
+        self.assertEqual(parsed["turnover"], 2233445566.0)
         self.assertEqual(parsed["source"], "kis-ws")
+
+    def test_parse_message_pipe_realtime_supports_multi_record_frame(self):
+        rec1 = self._build_h0stcnt0_record(symbol="005930", price="71300")
+        rec2 = self._build_h0stcnt0_record(symbol="000660", price="198500", change_pct="-0.52", turnover="987654321")
+        payload = "0|H0STCNT0|002|" + "^".join(rec1 + rec2)
+
+        parsed = parse_message(payload)
+
+        self.assertEqual(parsed["symbol"], "005930")
+        self.assertEqual(parsed["price"], 71300.0)
+
+    def test_parse_message_pipe_realtime_rejects_malformed_field_count(self):
+        malformed = self._build_h0stcnt0_record(symbol="005930")[:-1]
+        payload = "0|H0STCNT0|001|" + "^".join(malformed)
+
+        with self.assertRaises(ValueError):
+            parse_message(payload)
 
     def test_parse_message_raises_for_invalid_payload(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Summary
- replace heuristic pipe payload parsing with deterministic indexed parsing for `H0STCNT0`
- enforce strict field count validation: `len(fields) == data_cnt * 46`
- parse records by 46-field chunks and return first valid record
- keep JSON/dict parsing path unchanged
- add parser tests for:
  - trade-time present frame (price index correctness)
  - multi-record frame (`data_cnt=2`)
  - malformed field count rejection

## Verification
- `python3 -m unittest tests/test_kis_ws_parser.py -v`
- `python3 -m unittest tests/test_kis_ws_live_client.py -v`
- `python3 -m unittest tests/test_kis_ws_reconnect.py -v`

Refs #85
