### PR TITLE
fix: map SELL position provider failures to guarded risk response

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -65,8 +65,11 @@ def _make_sell_qty_provider(request: Request | None):
     if not hasattr(rest_client, 'get_positions'):
         return None
 
-    def _provider(account_id: str, symbol: str) -> int:
-        positions = rest_client.get_positions(account_id)
+    def _provider(account_id: str, symbol: str) -> int | None:
+        try:
+            positions = rest_client.get_positions(account_id)
+        except Exception:
+            return None
         for row in positions:
             if str(row.get('symbol', '')).strip() == symbol:
                 try:

--- a/tests/test_risk_policy_extended.py
+++ b/tests/test_risk_policy_extended.py
@@ -1,5 +1,6 @@
 import unittest
 from datetime import datetime as real_datetime
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from fastapi import HTTPException
@@ -73,6 +74,35 @@ class RiskPolicyExtendedTest(unittest.TestCase):
             })
         self.assertEqual(res.status_code, 200)
         self.assertEqual(res.json(), {'ok': True, 'reason': None})
+
+    def test_create_order_sell_does_not_500_when_positions_provider_raises(self):
+        client = TestClient(app)
+        original_service = app.state.quote_gateway_service
+
+        class _BrokenRestClient:
+            def get_positions(self, _account_id: str):
+                raise RuntimeError('INVALID_ORDER')
+
+        try:
+            app.state.quote_gateway_service = SimpleNamespace(rest_client=_BrokenRestClient())
+            with patch('app.api.routes.datetime') as mock_datetime:
+                mock_datetime.now.return_value = real_datetime(2026, 1, 2, 10, 0, 0)
+                res = client.post(
+                    '/v1/orders',
+                    headers={'Idempotency-Key': 'risk-provider-error-sell-1'},
+                    json={
+                        'account_id': 'A1',
+                        'symbol': '005930',
+                        'side': 'SELL',
+                        'qty': 1,
+                        'price': 70000,
+                        'order_type': 'LIMIT',
+                    },
+                )
+            self.assertEqual(res.status_code, 400)
+            self.assertIn(res.json().get('detail'), {'INSUFFICIENT_POSITION_QTY', 'POSITION_PROVIDER_UNAVAILABLE'})
+        finally:
+            app.state.quote_gateway_service = original_service
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- catch exceptions from `rest_client.get_positions()` in sell-qty provider path
- return provider-unavailable signal instead of propagating runtime exception
- avoids HTTP 500 in `POST /v1/orders` SELL path
- add regression test: provider raises INVALID_ORDER but route responds 400 (not 500)

## Verification
- `python3 -m unittest tests/test_risk_policy_extended.py -v`
- `python3 -m unittest tests/test_order_e2e_buy_sell.py -v`

Closes #89
